### PR TITLE
Add ignore = dirty to .gitmodules and update backlog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "babadeluxe-docs"]
 	path = babadeluxe-docs
 	url = https://github.com/simwai/babadeluxe-docs
+	ignore = dirty
 [submodule "agent-resources"]
 	path = agent-resources
 	url = https://github.com/simwai/agent-resources
+	ignore = dirty


### PR DESCRIPTION
This change adds `ignore = dirty` to all submodules in `.gitmodules` to prevent dirty submodule states from cluttering the main repository's status. It also updates the `backlog.md` to reflect this completed task.

---
*PR created automatically by Jules for task [1145680369538868578](https://jules.google.com/task/1145680369538868578) started by @simwai*