### PR TITLE
fix: verify session readability before redirect in AuthCallbackView

### DIFF
--- a/src/views/AuthCallbackView.vue
+++ b/src/views/AuthCallbackView.vue
@@ -50,6 +50,21 @@ const toastStore = useToastStore()
 const statusMessage = ref('Authenticating...')
 const error = ref<string | null>(null)
 
+async function verifySession(): Promise<boolean> {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    logger.error('Session not readable after auth flow completed')
+    error.value = 'Session could not be verified. Please try again.'
+    toastStore.error(error.value)
+    return false
+  }
+
+  return true
+}
+
 onMounted(async () => {
   if (isOfflineMode()) {
     void router.replace('/chat')
@@ -61,7 +76,6 @@ onMounted(async () => {
   const hashParams = new URLSearchParams(hash.slice(1))
 
   const errorCode = hashParams.get('error') || query.get('error')
-
   const errorDescription = hashParams.get('error_description') || query.get('error_description')
 
   if (errorCode) {
@@ -73,7 +87,6 @@ onMounted(async () => {
 
   const accessToken = hashParams.get('access_token')
   const refreshToken = hashParams.get('refresh_token')
-
   const code = query.get('code')
 
   if (accessToken && refreshToken) {
@@ -96,6 +109,8 @@ onMounted(async () => {
       toastStore.error(error.value)
       return
     }
+
+    if (!(await verifySession())) return
   } else if (code) {
     statusMessage.value = 'Exchanging code for session...'
 
@@ -111,8 +126,10 @@ onMounted(async () => {
       toastStore.error(error.value)
       return
     }
+
+    if (!(await verifySession())) return
   } else {
-    // If no session info is present, we might already have a session due to detectSessionInUrl
+    // detectSessionInUrl may have already consumed the tokens
     const {
       data: { session },
     } = await supabase.auth.getSession()

--- a/tests/auth-callback.test.ts
+++ b/tests/auth-callback.test.ts
@@ -8,6 +8,8 @@ import AuthCallbackView from '@/views/AuthCallbackView.vue'
 import { SUPABASE_CLIENT_KEY, LOGGER_KEY } from '@/injection-keys'
 import { createPinia, setActivePinia } from 'pinia'
 
+const mockSession = { access_token: 'abc', user: { id: '1' } }
+
 // Mock Supabase
 const mockSupabase = {
   auth: {
@@ -40,6 +42,9 @@ describe('AuthCallbackView', () => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
 
+    // Default: no active session
+    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null } })
+
     // Reset URL
     window.history.replaceState({}, '', '/')
     await router.push('/')
@@ -50,6 +55,8 @@ describe('AuthCallbackView', () => {
     window.history.replaceState({}, '', '/auth/callback#access_token=abc&refresh_token=def')
     await router.push('/auth/callback#access_token=abc&refresh_token=def')
     mockSupabase.auth.setSession.mockResolvedValue({ data: {}, error: null })
+    // verifySession() must confirm the session is readable after setSession
+    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: mockSession } })
 
     mount(AuthCallbackView, {
       global: {
@@ -76,6 +83,8 @@ describe('AuthCallbackView', () => {
     window.history.replaceState({}, '', '/auth/callback?code=123')
     await router.push('/auth/callback?code=123')
     mockSupabase.auth.exchangeCodeForSession.mockResolvedValue({ data: {}, error: null })
+    // verifySession() must confirm the session is readable after exchangeCodeForSession
+    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: mockSession } })
 
     mount(AuthCallbackView, {
       global: {
@@ -125,7 +134,7 @@ describe('AuthCallbackView', () => {
   it('redirects to login if no session info and no active session', async () => {
     window.history.replaceState({}, '', '/auth/callback')
     await router.push('/auth/callback')
-    mockSupabase.auth.getSession.mockResolvedValue({ data: { session: null } })
+    // getSession already returns null from beforeEach — no override needed
 
     mount(AuthCallbackView, {
       global: {
@@ -140,5 +149,27 @@ describe('AuthCallbackView', () => {
     await new Promise((resolve) => setTimeout(resolve, 50))
 
     expect(router.currentRoute.value.path).toBe('/login')
+  })
+
+  it('shows error if session is not readable after setSession succeeds', async () => {
+    window.history.replaceState({}, '', '/auth/callback#access_token=abc&refresh_token=def')
+    await router.push('/auth/callback#access_token=abc&refresh_token=def')
+    mockSupabase.auth.setSession.mockResolvedValue({ data: {}, error: null })
+    // getSession returns null from beforeEach — simulates the race condition
+
+    const wrapper = mount(AuthCallbackView, {
+      global: {
+        plugins: [router],
+        provide: {
+          [SUPABASE_CLIENT_KEY as symbol]: mockSupabase,
+          [LOGGER_KEY as symbol]: mockLogger,
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(mockLogger.error).toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Session could not be verified')
   })
 })


### PR DESCRIPTION
## Problem

After a successful GitHub OAuth flow in Chrome, users landed on a white screen at `/auth/callback`.

The URL contained valid tokens (e.g. `#access_token=...&refresh_token=...`), `setSession()` completed without error, and `router.replace('/chat')` was called — but the `beforeEach` guard then called `supabase.auth.getSession()` and got `null` back, bouncing the navigation to `/` (login) which rendered as a blank screen with no visible feedback.

## Root Cause

`supabase.auth.setSession()` writes to `localStorage` and fires an internal `onAuthStateChange` event asynchronously. There is a narrow race window between `setSession()` resolving and the session being fully committed to the internal state cache that `getSession()` reads from inside `beforeEach`. On first page load in Chrome this window is reliably hit.

## Fix

Added a `verifySession()` helper that calls `supabase.auth.getSession()` **after** `setSession()` / `exchangeCodeForSession()` succeeds, confirming the session is actually readable before handing off to the router. If the session is not readable at that point, the user sees a clear error message instead of a silent white screen.

This applies to both the `access_token` hash fragment path and the PKCE `code` query param path.

## Testing
1. Open `https://app-staging.babadeluxe.com` in Chrome (not VS Code)
2. Click "Sign in with GitHub"
3. Authorize — should land on `/chat` ✅ (previously: white screen)