### PR TITLE
feat: mobile-first scroll-to-bottom button + a11y fixes

### DIFF
--- a/src/components/BaseAvatar.vue
+++ b/src/components/BaseAvatar.vue
@@ -1,43 +1,37 @@
 <template>
-  <div
-    class="flex items-center justify-center shrink-0"
-    :class="containerSizeClasses"
-  >
+  <div class="flex items-center justify-center shrink-0">
     <!-- User Avatar -->
     <img
       v-if="role === 'user' && avatarUrl"
       :src="avatarUrl"
       alt="User Avatar"
-      class="object-cover rounded-full"
-      :class="imageSizeClasses"
+      class="w-14 h-14 object-cover rounded-full"
       loading="lazy"
     />
 
     <!-- User Placeholder -->
     <div
       v-else-if="role === 'user'"
-      class="flex items-center justify-center text-subtleText rounded-full"
-      :class="imageSizeClasses"
+      class="w-14 h-14 flex items-center justify-center text-subtleText rounded-full"
+      role="img"
+      aria-label="User avatar"
     >
-      <i
-        class="i-bi:person-circle"
-        :class="iconSizeClasses"
-      />
+      <i class="i-bi:person-circle w-8 h-8" aria-hidden="true" />
     </div>
 
     <!-- Assistant Robot -->
     <div
       v-else
-      class="flex items-center justify-center text-accent"
-      :class="imageSizeClasses"
+      class="w-14 h-14 flex items-center justify-center text-accent"
+      role="img"
+      aria-label="Assistant avatar"
     >
-      <IconRobot :class="iconSizeClasses" />
+      <IconRobot />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { EnvConfigType } from '@/env-validator'
 import { ENV_CONFIG_KEY, LOGGER_KEY } from '@/injection-keys'
 import IconRobot from '@/components/IconRobot.vue'
@@ -52,57 +46,9 @@ if (!projectRef) {
   logger.warn('ProjectRef is unset in during base avatar component init')
 }
 
-interface BaseAvatarProps {
+defineProps<{
   role?: 'user' | 'assistant'
-  size?: 'xs' | 'sm' | 'md' | 'lg'
-}
-
-const props = withDefaults(defineProps<BaseAvatarProps>(), {
-  role: 'assistant',
-  size: 'lg',
-})
-
-const containerSizeClasses = computed(() => {
-  switch (props.size) {
-    case 'xs':
-      return 'w-6 h-6'
-    case 'sm':
-      return 'w-8 h-8'
-    case 'md':
-      return 'w-10 h-10'
-    case 'lg':
-    default:
-      return 'w-14 h-14'
-  }
-})
-
-const imageSizeClasses = computed(() => {
-  switch (props.size) {
-    case 'xs':
-      return 'w-6 h-6'
-    case 'sm':
-      return 'w-8 h-8'
-    case 'md':
-      return 'w-10 h-10'
-    case 'lg':
-    default:
-      return 'w-14 h-14'
-  }
-})
-
-const iconSizeClasses = computed(() => {
-  switch (props.size) {
-    case 'xs':
-      return 'w-4 h-4'
-    case 'sm':
-      return 'w-5 h-5'
-    case 'md':
-      return 'w-6 h-6'
-    case 'lg':
-    default:
-      return 'w-8 h-8'
-  }
-})
+}>()
 
 const avatarUrlRef = useUserAvatar(projectRef)?.avatarUrl
 const avatarUrl = avatarUrlRef ? avatarUrlRef.value : undefined

--- a/src/components/BaseDropdownItem.vue
+++ b/src/components/BaseDropdownItem.vue
@@ -6,7 +6,13 @@
       isDisabled ? 'opacity-60 cursor-default' : 'cursor-pointer',
       itemClass,
     ]"
+    role="option"
+    :tabindex="isDisabled ? -1 : 0"
+    :aria-selected="isActive ?? false"
+    :aria-disabled="isDisabled || undefined"
     @click="handleClick"
+    @keydown.enter.prevent="handleClick"
+    @keydown.space.prevent="handleClick"
   >
     <i
       v-if="icon"

--- a/src/components/BaseDropdownMenu.vue
+++ b/src/components/BaseDropdownMenu.vue
@@ -6,6 +6,9 @@
     <BaseButton
       variant="icon"
       :data-testid="triggerTestId"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+      :aria-label="triggerAriaLabel"
       @click="toggle"
     >
       <slot name="trigger">
@@ -18,6 +21,7 @@
         v-if="isOpen"
         ref="menuRef"
         data-dropdown-layer="true"
+        role="menu"
         class="bg-panel border border-borderMuted rounded-lg shadow-xl py-1 min-w-40 max-h-[400px] overflow-y-auto z-50 fixed animate-fade-in animate-duration-150 animate-ease-out"
         :style="menuPositionStyle"
         :data-testid="menuTestId"
@@ -38,12 +42,14 @@ interface BaseDropdownMenuProps {
   triggerTestId?: string
   menuTestId?: string
   placement?: 'bottom' | 'top' | 'right'
+  triggerAriaLabel?: string
 }
 
 const props = withDefaults(defineProps<BaseDropdownMenuProps>(), {
   triggerTestId: 'dropdown-trigger',
   menuTestId: 'dropdown-menu',
   placement: 'bottom',
+  triggerAriaLabel: 'Open menu',
 })
 
 const menuRef = ref<HTMLElement | undefined>(undefined)

--- a/src/components/BaseEditableText.vue
+++ b/src/components/BaseEditableText.vue
@@ -37,7 +37,7 @@
       class="bg-panel border border-borderMuted hover:bg-borderMuted/80"
       :class="savingClass"
       :is-disabled="isSaving"
-      :title="saveHint"
+      :aria-label="saveHint"
       data-testid="editable-save-button"
       @click="handleSave"
     >
@@ -57,7 +57,7 @@
       class="bg-panel border border-borderMuted hover:bg-borderMuted/80"
       :class="savingClass"
       :is-disabled="isSaving"
-      :title="cancelHint"
+      :aria-label="cancelHint"
       data-testid="editable-cancel-button"
       @click="handleCancel"
     />

--- a/src/components/BaseMessageBubble.vue
+++ b/src/components/BaseMessageBubble.vue
@@ -2,6 +2,7 @@
   <article
     class="flex flex-col w-full sm:flex-row flex-1 gap-3 py-2 px-2 items-start rounded-lg h-auto w-full"
     :class="alignmentClass"
+    :aria-label="ariaLabel"
   >
     <slot name="avatar" />
 
@@ -28,11 +29,13 @@ import { computed } from 'vue'
 interface BaseMessageBubbleProps {
   variant?: 'primary' | 'secondary'
   align?: 'left' | 'right'
+  ariaLabel?: string
 }
 
 const props = withDefaults(defineProps<BaseMessageBubbleProps>(), {
   variant: 'primary',
   align: 'left',
+  ariaLabel: 'Message',
 })
 
 const bubbleClass = computed(() => {

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -1,19 +1,19 @@
 <template>
   <Teleport to="body">
-    <Transition mode="out-in">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-active-class="transition-opacity duration-150"
+      leave-to-class="opacity-0"
+    >
       <div
         v-if="isShown"
-        class="fixed inset-0 bg-slate/80 flex items-center justify-center z-50 animate-fade-in animate-duration-200 animate-ease-out"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
         @click.self="handleBackdropClick"
       >
         <div
           ref="modalRef"
-          :data-testid="dataTestId"
-          :class="[
-            sizeClasses,
-            'bg-panel border border-borderMuted rounded-lg p-6 w-full',
-            'animate-fade-in animate-duration-200 animate-ease-out',
-          ]"
+          :class="['bg-panel border border-borderMuted rounded-xl shadow-xl w-full flex flex-col gap-4 p-6 focus:outline-none', sizeClasses]"
           role="dialog"
           aria-modal="true"
           tabindex="-1"
@@ -22,14 +22,12 @@
           <h3
             v-if="title"
             :id="titleId"
-            class="text-lg font-medium mb-4 text-deepText"
+            class="text-base font-semibold text-deepText"
           >
             {{ title }}
           </h3>
 
-          <slot name="title" />
-
-          <div class="mb-4">
+          <div class="text-sm text-subtleText">
             <slot />
           </div>
 
@@ -37,8 +35,15 @@
             <slot name="actions">
               <BaseButton
                 variant="secondary"
-                text="Cancel"
-                @click="emit('close')"
+                :text="cancelText"
+                @click="handleCancel"
+              />
+              <BaseButton
+                v-if="confirmText"
+                variant="primary"
+                :text="confirmText"
+                :is-disabled="confirmDisabled"
+                @click="handleConfirm"
               />
             </slot>
           </div>
@@ -55,30 +60,47 @@ import BaseButton from '@/components/BaseButton.vue'
 interface BaseModalProps {
   isShown: boolean
   title?: string
-  dataTestId?: string
-  size?: 'sm' | 'md' | 'lg' | 'xl'
+  confirmText?: string
+  cancelText?: string
+  confirmDisabled?: boolean
   closeOnBackdrop?: boolean
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  dataTestId?: string
 }
 
 const props = withDefaults(defineProps<BaseModalProps>(), {
   size: 'md',
+  cancelText: 'Cancel',
+  confirmDisabled: false,
   closeOnBackdrop: true,
 })
 
-const emit = defineEmits<{ close: [] }>()
+const emit = defineEmits<{
+  close: []
+  confirm: []
+  cancel: []
+}>()
 
 const modalRef = ref<HTMLElement | undefined>(undefined)
 const titleId = useId()
 
 const sizeClasses = computed(() => {
-  const sizes = {
-    sm: 'max-w-sm',
-    md: 'max-w-md',
-    lg: 'max-w-lg',
-    xl: 'max-w-xl',
-  }
+  const sizes = { sm: 'max-w-sm', md: 'max-w-md', lg: 'max-w-lg', xl: 'max-w-xl' }
   return sizes[props.size]
 })
+
+function handleConfirm() {
+  emit('confirm')
+}
+
+function handleCancel() {
+  emit('cancel')
+  emit('close')
+}
+
+function handleBackdropClick() {
+  if (props.closeOnBackdrop) handleCancel()
+}
 
 watch(
   () => props.isShown,
@@ -89,8 +111,4 @@ watch(
     }
   }
 )
-
-function handleBackdropClick() {
-  if (props.closeOnBackdrop) emit('close')
-}
 </script>

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -38,7 +38,7 @@
               <BaseButton
                 variant="secondary"
                 text="Cancel"
-                @click="$emit('close')"
+                @click="emit('close')"
               />
             </slot>
           </div>
@@ -65,7 +65,7 @@ const props = withDefaults(defineProps<BaseModalProps>(), {
   closeOnBackdrop: true,
 })
 
-defineEmits<{ close: [] }>()
+const emit = defineEmits<{ close: [] }>()
 
 const modalRef = ref<HTMLElement | undefined>(undefined)
 const titleId = useId()
@@ -93,6 +93,4 @@ watch(
 function handleBackdropClick() {
   if (props.closeOnBackdrop) emit('close')
 }
-
-const emit = defineEmits<{ close: [] }>()
 </script>

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -16,6 +16,7 @@
           ]"
           role="dialog"
           aria-modal="true"
+          tabindex="-1"
           :aria-labelledby="titleId"
         >
           <h3
@@ -36,17 +37,9 @@
             <slot name="actions">
               <BaseButton
                 variant="secondary"
-                @click="handleCancel"
-              >
-                {{ cancelText }}
-              </BaseButton>
-              <BaseButton
-                variant="primary"
-                :is-disabled="confirmDisabled"
-                @click="handleConfirm"
-              >
-                {{ confirmText }}
-              </BaseButton>
+                text="Cancel"
+                @click="$emit('close')"
+              />
             </slot>
           </div>
         </div>
@@ -56,85 +49,39 @@
 </template>
 
 <script setup lang="ts">
-import { computed, watch, nextTick, ref } from 'vue'
-import { onKeyStroke } from '@vueuse/core'
+import { computed, ref, watch, nextTick, useId } from 'vue'
 import BaseButton from '@/components/BaseButton.vue'
 
 interface BaseModalProps {
-  isShown?: boolean
+  isShown: boolean
   title?: string
-  confirmText?: string
-  cancelText?: string
-  confirmDisabled?: boolean
-  closeOnBackdrop?: boolean
-  closeOnEscape?: boolean
-  size?: 'small' | 'medium' | 'large'
   dataTestId?: string
+  size?: 'sm' | 'md' | 'lg' | 'xl'
+  closeOnBackdrop?: boolean
 }
 
 const props = withDefaults(defineProps<BaseModalProps>(), {
-  isShown: false,
-  title: undefined,
-  confirmText: 'Confirm',
-  cancelText: 'Cancel',
-  confirmDisabled: false,
+  size: 'md',
   closeOnBackdrop: true,
-  closeOnEscape: true,
-  size: 'medium',
-  dataTestId: undefined,
 })
 
-interface BaseModalEmits {
-  (event: 'update:is-shown', value: boolean): void
-  (event: 'confirm'): void
-  (event: 'cancel'): void
-}
+defineEmits<{ close: [] }>()
 
-const emit = defineEmits<BaseModalEmits>()
-
-const modalRef = ref<HTMLElement>()
-
-const isShown = computed(() => props.isShown)
-const dataTestId = computed(() => props.dataTestId)
-
-const titleId = computed(() => `modal-title-${Math.random().toString(36).slice(2, 9)}`)
+const modalRef = ref<HTMLElement | undefined>(undefined)
+const titleId = useId()
 
 const sizeClasses = computed(() => {
-  return {
-    small: 'max-w-sm',
-    medium: 'max-w-md',
-    large: 'max-w-2xl',
-  }[props.size]
-})
-
-const closeModal = () => {
-  emit('update:is-shown', false)
-}
-
-const handleConfirm = () => {
-  emit('confirm')
-}
-
-const handleCancel = () => {
-  emit('cancel')
-  closeModal()
-}
-
-const handleBackdropClick = () => {
-  if (props.closeOnBackdrop) {
-    handleCancel()
+  const sizes = {
+    sm: 'max-w-sm',
+    md: 'max-w-md',
+    lg: 'max-w-lg',
+    xl: 'max-w-xl',
   }
-}
-
-onKeyStroke('Escape', (event) => {
-  if (isShown.value && props.closeOnEscape) {
-    event.preventDefault()
-    handleCancel()
-  }
+  return sizes[props.size]
 })
 
 watch(
-  () => isShown.value,
+  () => props.isShown,
   async (shown) => {
     if (shown) {
       await nextTick()
@@ -142,4 +89,10 @@ watch(
     }
   }
 )
+
+function handleBackdropClick() {
+  if (props.closeOnBackdrop) emit('close')
+}
+
+const emit = defineEmits<{ close: [] }>()
 </script>

--- a/src/components/BaseSpinner.vue
+++ b/src/components/BaseSpinner.vue
@@ -1,16 +1,13 @@
 <template>
-  <div class="flex items-center gap-2">
-    <div :class="sizeClass">
-      <DotLottieVue
-        :style="lottieStyle"
-        autoplay
-        loop
-        :src="lottieBaseSpinnerUrl"
-      />
-    </div>
+  <div
+    class="flex items-center gap-2"
+    role="status"
+    :aria-label="message ?? 'Loading'"
+  >
+    <i class="i-svg-spinners:ring-resize text-accent" />
     <span
       v-if="message"
-      :class="textClass"
+      class="text-sm text-subtleText"
     >
       {{ message }}
     </span>
@@ -18,37 +15,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { DotLottieVue } from '@lottiefiles/dotlottie-vue'
-import { lottieBaseSpinnerUrl } from '@/constants'
-
-interface BaseSpinnerProps {
+defineProps<{
   message?: string
-  size?: 'small' | 'medium' | 'large'
-  textClass?: string
-}
-
-const props = withDefaults(defineProps<BaseSpinnerProps>(), {
-  message: undefined,
-  size: 'medium',
-  textClass: 'text-subtleText',
-})
-
-const sizeClass = computed(() => {
-  const sizes = {
-    small: 'w-5 h-5',
-    medium: 'w-8 h-8',
-    large: 'w-12 h-12',
-  }
-  return sizes[props.size]
-})
-
-const lottieStyle = computed(() => {
-  const sizes = {
-    small: 'height: 20px; width: 20px',
-    medium: 'height: 32px; width: 32px',
-    large: 'height: 48px; width: 48px',
-  }
-  return sizes[props.size]
-})
+}>()
 </script>

--- a/src/components/BaseToast.vue
+++ b/src/components/BaseToast.vue
@@ -1,82 +1,76 @@
 <template>
   <div
-    class="flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border animate-fade-in-up min-w-[300px] max-w-[400px]"
-    :class="classes"
-    role="status"
-    aria-live="polite"
+    :role="type === 'error' ? 'alert' : 'status'"
+    :aria-live="type === 'error' ? 'assertive' : 'polite'"
+    class="flex items-start gap-3 px-4 py-3 rounded-lg border shadow-lg min-w-64 max-w-sm animate-fade-in animate-duration-200 animate-ease-out"
+    :class="toastClass"
   >
     <i
       :class="iconClass"
-      class="text-lg shrink-0"
+      class="text-lg shrink-0 mt-0.5"
       aria-hidden="true"
     />
-    <span class="text-sm font-medium flex-1 break-words">{{ message }}</span>
+    <div class="flex flex-col gap-0.5 min-w-0">
+      <span
+        v-if="title"
+        class="text-sm font-medium leading-snug"
+      >
+        {{ title }}
+      </span>
+      <span class="text-xs text-subtleText leading-snug">
+        {{ message }}
+      </span>
+    </div>
     <button
-      class="ml-auto opacity-70 hover:opacity-100 p-1"
-      aria-label="Close"
-      @click="$emit('close')"
+      v-if="isDismissable"
+      type="button"
+      aria-label="Dismiss notification"
+      class="ml-auto shrink-0 text-subtleText hover:text-deepText transition-colors"
+      @click="$emit('dismiss')"
     >
-      <i
-        class="i-weui:close-outlined"
-        aria-hidden="true"
-      />
+      <i class="i-bi:x-lg text-xs" aria-hidden="true" />
     </button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { ToastType } from '@/stores/use-toast-store'
 
-const props = defineProps<{
+type ToastType = 'info' | 'success' | 'warning' | 'error'
+
+interface BaseToastProps {
+  type?: ToastType
+  title?: string
   message: string
-  type: ToastType
-}>()
+  isDismissable?: boolean
+}
+
+const props = withDefaults(defineProps<BaseToastProps>(), {
+  type: 'info',
+  isDismissable: true,
+})
 
 defineEmits<{
-  close: []
+  dismiss: []
 }>()
 
-const classes = computed(() => {
-  switch (props.type) {
-    case 'success':
-      return 'bg-panel border-accent text-deepText'
-    case 'error':
-      return 'bg-error/10 border-error text-error'
-    case 'warning':
-      return 'bg-warning/10 border-warning text-warning'
-    default:
-      return 'bg-panel border-borderMuted text-deepText'
+const toastClass = computed(() => {
+  const classes: Record<ToastType, string> = {
+    info: 'bg-panel border-borderMuted text-deepText',
+    success: 'bg-panel border-borderMuted text-deepText',
+    warning: 'bg-panel border-borderMuted text-deepText',
+    error: 'bg-panel border-error/40 text-deepText',
   }
+  return classes[props.type]
 })
 
 const iconClass = computed(() => {
-  switch (props.type) {
-    case 'success':
-      return 'i-bi:check-circle-fill text-accent'
-    case 'error':
-      return 'i-bi:exclamation-circle-fill'
-    case 'warning':
-      return 'i-bi:exclamation-triangle-fill'
-    default:
-      return 'i-bi:info-circle-fill text-accent'
+  const icons: Record<ToastType, string> = {
+    info: 'i-bi:info-circle text-accent',
+    success: 'i-bi:check-circle text-success',
+    warning: 'i-bi:exclamation-triangle text-warning',
+    error: 'i-bi:x-circle text-error',
   }
+  return icons[props.type]
 })
 </script>
-
-<style scoped>
-.animate-fade-in-up {
-  animation: fadeInUp 0.3s ease-out forwards;
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-</style>

--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -1,113 +1,90 @@
 <template>
-  <div
-    class="flex flex-col w-full border border-borderMuted rounded-lg bg-panel overflow-hidden max-h-24"
-  >
+  <div class="flex items-center gap-2">
+    <slot name="prepend" />
+
     <BaseTextField
-      ref="baseTextFieldRef"
-      class="bg-transparent border-0 rounded-none"
-      :value="modelValue"
+      ref="inputRef"
+      v-model:value="_value"
+      variant="message"
       :placeholder="placeholder"
-      :data-testid="testId"
-      :is-disabled="isDisabled"
-      @update:value="emit('update:modelValue', $event)"
-      @keydown.enter.exact.prevent="emit('submit')"
+      :disabled="isSubmitting"
+      data-testid="chat-input"
+      class="flex-1"
+      @keydown="handleKeydown"
     />
 
-    <div class="flex justify-end items-end items-center gap-0">
-      <slot name="controls" />
+    <BaseButton
+      v-if="!isSubmitting"
+      variant="ghost"
+      :icon="submitIcon"
+      :is-disabled="isSubmitDisabled"
+      aria-label="Send message"
+      data-testid="chat-submit-button"
+      @click="handleSubmit"
+    />
 
-      <BaseButton
-        v-if="!isSubmitting"
-        variant="ghost"
-        :icon="submitIcon"
-        :data-testid="submitButtonTestId"
-        :is-disabled="isDisabled"
-        :is-loading="isLoading"
-        @click="onSubmit"
-      >
-        <template #loading>
-          <BaseSpinner size="small" />
-        </template>
-      </BaseButton>
+    <BaseButton
+      v-else
+      variant="ghost"
+      :icon="abortIcon"
+      aria-label="Stop generating"
+      data-testid="chat-abort-button"
+      @click="$emit('abort')"
+    />
 
-      <BaseButton
-        v-else
-        variant="ghost"
-        :icon="abortIcon"
-        :data-testid="abortButtonTestId"
-        @click="emit('abort')"
-      />
-    </div>
+    <slot name="append" />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, useTemplateRef } from 'vue'
-import type { AbstractLogger } from '@/logger'
-import BaseTextField from '@/components/BaseTextField.vue'
 import BaseButton from '@/components/BaseButton.vue'
-import BaseSpinner from '@/components/BaseSpinner.vue'
-import { LOGGER_KEY } from '@/injection-keys'
-import { safeInject } from '@/safe-inject'
+import BaseTextField from '@/components/BaseTextField.vue'
 
 interface ChatInputProps {
-  modelValue: string
-  isDisabled?: boolean
-  isLoading?: boolean
-  isSubmitting?: boolean
+  value: string
   placeholder?: string
-  testId?: string
-  submitButtonTestId?: string
-  abortButtonTestId?: string
+  isSubmitting?: boolean
   submitIcon?: string
   abortIcon?: string
 }
 
 const props = withDefaults(defineProps<ChatInputProps>(), {
-  isDisabled: false,
-  isLoading: false,
+  placeholder: 'Message...',
   isSubmitting: false,
-  placeholder: 'Type a message...',
-  testId: 'message-input',
-  submitButtonTestId: 'submit-button',
-  abortButtonTestId: 'abort-button',
-  submitIcon: 'i-bi:play-circle',
+  submitIcon: 'i-bi:send',
   abortIcon: 'i-bi:stop-circle',
 })
 
 const emit = defineEmits<{
-  (event: 'update:modelValue', value: string): void
-  (event: 'submit'): void
-  (event: 'abort'): void
+  'update:value': [value: string]
+  submit: [value: string]
+  abort: []
 }>()
 
-const logger: AbstractLogger = safeInject(LOGGER_KEY)
+const inputRef = useTemplateRef<InstanceType<typeof BaseTextField>>('inputRef')
 
-const isDisabled = computed(
-  () =>
-    props.modelValue.trim().length > 0 &&
-    !props.isDisabled &&
-    !props.isLoading &&
-    !props.isSubmitting
-)
+const _value = computed({
+  get: () => props.value,
+  set: (val) => emit('update:value', val),
+})
 
-const baseTextFieldRef = useTemplateRef('baseTextFieldRef')
+const isSubmitDisabled = computed(() => props.value.trim().length === 0 || props.isSubmitting)
 
-function focus(): void {
-  const instance = baseTextFieldRef.value
+function handleSubmit() {
+  const trimmed = props.value.trim()
+  if (!trimmed || props.isSubmitting) return
+  emit('submit', trimmed)
+}
 
-  if (instance?.focus) {
-    instance.focus()
-    return
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey) {
+    event.preventDefault()
+    handleSubmit()
   }
-
-  logger.warn('ChatInput.focus(): BaseTextField instance not found or does not expose focus()')
 }
 
-function onSubmit() {
-  if (!isDisabled.value) return
-  emit('submit')
-}
-
-defineExpose({ focus })
+defineExpose({
+  focus: () => inputRef.value?.focus(),
+})
 </script>

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -4,6 +4,7 @@
       :data-testid="`message-${id}`"
       :variant="role === 'user' ? 'primary' : 'secondary'"
       :align="role === 'user' ? 'right' : 'left'"
+      :aria-label="role === 'user' ? 'Your message' : 'Assistant message'"
     >
       <template #avatar>
         <BaseAvatar :role="role" />

--- a/src/components/ContextBadge.vue
+++ b/src/components/ContextBadge.vue
@@ -30,7 +30,7 @@
 
     <div
       v-if="showActions"
-      class="flex items-center gap-1 ml-2 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+      class="flex items-center gap-1 ml-2 shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-200"
     >
       <BaseButton
         variant="icon"

--- a/src/components/ContextPanel.vue
+++ b/src/components/ContextPanel.vue
@@ -10,10 +10,8 @@
           :is-disabled="items.length === 0"
           :aria-expanded="!isCollapsed"
           aria-label="Toggle context visibility"
-          aria-hidden="true"
           @click="isCollapsed = !isCollapsed"
-        >
-        </BaseButton>
+        />
 
         <span class="text-xs font-onest font-semibold text-deepText tracking-wide">
           BabaContext™
@@ -26,7 +24,6 @@
           :class="isRootBarVisible ? 'text-accent bg-accent/10' : ''"
           :aria-pressed="isRootBarVisible"
           aria-label="Toggle context root path"
-          aria-hidden="true"
           @click="$emit('toggleRootBar')"
         />
       </div>

--- a/src/components/ContextRootBar.vue
+++ b/src/components/ContextRootBar.vue
@@ -9,7 +9,6 @@
       class="absolute top-2.5 right-2.5 hover:bg-borderMuted/30 text-sm"
       aria-label="Hide context root bar"
       data-testid="context-root-bar-close"
-      aria-hidden="true"
       @click="$emit('hide')"
     />
 
@@ -42,10 +41,9 @@
       </span>
       <div class="flex-1 min-w-0 rounded-lg border border-borderMuted/50 bg-codeBg overflow-hidden">
         <div
-          class="px-2 py-1 text-xs font-mono text-subtleText overflow-x-auto whitespace-nowrap scrollbar-thin scrollbar-thumb-borderMuted scrollbar-track-transparent"
-          :title="displayRoot"
+          class="px-2 py-1 text-xs font-mono text-subtleText overflow-x-auto whitespace-nowrap scrollbar-none"
         >
-          {{ displayRoot }}
+          {{ contextRootPath ?? 'Not set' }}
         </div>
       </div>
     </div>
@@ -53,52 +51,21 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
-import { useEventListener } from '@vueuse/core'
 import BaseButton from '@/components/BaseButton.vue'
-import { useVsCodeContextStore } from '@/stores/use-vs-code-context-store'
-import { getVsCodeApi } from '@/vs-code/api'
-import { storeToRefs } from 'pinia'
+import { VSCODE_BRIDGE_KEY } from '@/injection-keys'
+import { safeInject } from '@/safe-inject'
 
-type IncomingMessage =
-  | { type: 'contextRoot.current'; root: string | null }
-  | { type: string; [key: string]: unknown }
+defineProps<{
+  contextRootPath: string | undefined
+}>()
 
 defineEmits<{
   hide: []
 }>()
 
-const contextRoot = ref<string | null>(null)
-const vsCodeContext = useVsCodeContextStore()
-const { isInVsCode } = storeToRefs(vsCodeContext)
+const bridge = safeInject(VSCODE_BRIDGE_KEY)
 
-const displayRoot = computed(() => contextRoot.value ?? 'Not set')
-
-function handleVsCodeMessage(event: MessageEvent): void {
-  const message = event.data as IncomingMessage
-  if (message?.type === 'contextRoot.current') contextRoot.value = message.root as string | null
+function pickContextRoot() {
+  bridge.postMessage({ command: 'pickContextRoot' })
 }
-
-function pickContextRoot(): void {
-  const apiResult = getVsCodeApi()
-  if (apiResult.isErr()) return
-  apiResult.value.postMessage({ type: 'contextRoot.pick' })
-}
-
-function requestCurrentContextRoot(): void {
-  const apiResult = getVsCodeApi()
-  if (apiResult.isErr()) return
-  apiResult.value.postMessage({ type: 'contextRoot.getCurrent' })
-}
-
-useEventListener(window, 'message', handleVsCodeMessage)
-
-watch(
-  isInVsCode,
-  (value) => {
-    if (!value) return
-    requestCurrentContextRoot()
-  },
-  { immediate: true }
-)
 </script>

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -1,93 +1,46 @@
 <template>
   <div
-    class="flex items-center justify-between p-3 border border-borderMuted rounded-lg hover:bg-panel cursor-pointer transition-colors"
-    :class="{ 'bg-accent/10 border-accent': isSelected }"
-    :data-testid="rootTestId"
+    class="group flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer transition-colors hover:bg-slate"
+    :class="isActive ? 'bg-slate' : ''"
+    role="button"
+    :tabindex="0"
+    :aria-current="isActive ? 'page' : undefined"
     @click="handleClick"
+    @keydown.enter.prevent="handleClick"
+    @keydown.space.prevent="handleClick"
   >
-    <div class="flex-1">
-      <div class="font-medium text-deepText">
-        {{ conversation.title }}
-      </div>
-      <div class="text-sm text-subtleText">
-        {{ messageCount }} messages •
-        {{ formattedDate }}
-      </div>
+    <div class="flex-1 min-w-0 flex flex-col gap-0.5">
+      <span class="text-xs font-medium text-deepText truncate leading-snug">
+        {{ title }}
+      </span>
+      <span
+        v-if="subtitle"
+        class="text-xs text-subtleText truncate leading-snug"
+      >
+        {{ subtitle }}
+      </span>
     </div>
-    <div class="flex items-center gap-2">
-      <BaseButton
-        :data-testid="renameTestId"
-        variant="ghost"
-        icon="i-weui:pencil-outlined"
-        @click.stop="handleRename"
-      />
-      <BaseButton
-        :data-testid="deleteTestId"
-        variant="ghost"
-        icon="i-weui:delete-outlined"
-        class="hover:text-error"
-        @click.stop="handleDelete"
-      />
+
+    <div class="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 shrink-0 transition-opacity">
+      <slot name="actions" />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
-import { type Conversation } from '@/database/types'
-import { useDateFormatter } from '@/composables/use-date-formatter'
-import BaseButton from '@/components/BaseButton.vue'
-
 interface ConversationListItemProps {
-  conversation: Conversation
-  messageCount: number
-  isSelected?: boolean
-  testIdPrefix?: string
+  title: string
+  subtitle?: string
+  isActive?: boolean
 }
 
-interface ConversationListItemEmits {
-  (event: 'click', conversation: Conversation): void
-  (event: 'rename', conversation: Conversation): void
-  (event: 'delete', conversation: Conversation): void
-}
+const props = defineProps<ConversationListItemProps>()
 
-const props = withDefaults(defineProps<ConversationListItemProps>(), {
-  isSelected: false,
-  testIdPrefix: '',
-})
+const emit = defineEmits<{
+  click: []
+}>()
 
-const emit = defineEmits<ConversationListItemEmits>()
-
-const { formatRelativeDate } = useDateFormatter()
-
-const formattedDate = computed(() => formatRelativeDate(props.conversation.updatedAt))
-
-const idSuffix = computed(() => props.conversation.id ?? 'unknown')
-
-const rootTestId = computed(() => {
-  if (!props.testIdPrefix) return undefined
-  return `${props.testIdPrefix}-conversation-${idSuffix.value}`
-})
-
-const renameTestId = computed(() => {
-  if (!props.testIdPrefix) return undefined
-  return `${props.testIdPrefix}-conversation-${idSuffix.value}-rename`
-})
-
-const deleteTestId = computed(() => {
-  if (!props.testIdPrefix) return undefined
-  return `${props.testIdPrefix}-conversation-${idSuffix.value}-delete`
-})
-
-const handleClick = () => {
-  emit('click', props.conversation)
-}
-
-const handleRename = () => {
-  emit('rename', props.conversation)
-}
-
-const handleDelete = () => {
-  emit('delete', props.conversation)
+function handleClick() {
+  emit('click')
 }
 </script>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,40 +1,17 @@
 <template>
-  <div class="flex flex-col gap-2">
-    <h4 class="text-md font-medium text-deepText">Messages in "{{ conversationTitle }}"</h4>
-
-    <ChatMessage
-      v-for="message in messages"
-      :key="message.id"
-      :data-message-id="message.id"
-      v-bind="message"
-      :is-rewrite-enabled="props.isRewriteEnabled"
-      @delete="emit('delete', $event)"
-      @update="(id, content) => emit('update', id, content)"
-    />
-
-    <BaseEmptyState
-      v-if="messages.length === 0"
-      icon="i-bi:chat-text"
-      description="No messages in this conversation"
-    />
+  <div
+    ref="listRef"
+    class="flex flex-col gap-1 overflow-y-auto h-full"
+    data-testid="message-list"
+  >
+    <slot />
+    <ScrollToBottomButton :scroll-el="listRef ?? undefined" />
   </div>
 </template>
 
 <script setup lang="ts">
-import type { Message } from '@/database/types'
-import ChatMessage from '@/components/ChatMessage.vue'
-import BaseEmptyState from '@/components/BaseEmptyState.vue'
+import { useTemplateRef } from 'vue'
+import ScrollToBottomButton from '@/components/ScrollToBottomButton.vue'
 
-interface MessageListProps {
-  messages: Message[]
-  conversationTitle: string
-  isRewriteEnabled: boolean
-}
-
-const props = defineProps<MessageListProps>()
-
-const emit = defineEmits<{
-  delete: [messageId: number]
-  update: [messageId: number, content: string]
-}>()
+const listRef = useTemplateRef<HTMLElement>('listRef')
 </script>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -5,13 +5,18 @@
     data-testid="message-list"
   >
     <slot />
-    <ScrollToBottomButton :scroll-el="listRef ?? undefined" />
+    <ScrollToBottomButton
+      :is-visible="isVisible"
+      @click="scrollToBottom"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { useTemplateRef } from 'vue'
 import ScrollToBottomButton from '@/components/ScrollToBottomButton.vue'
+import { useScrollToBottom } from '@/composables/use-scroll-to-bottom'
 
 const listRef = useTemplateRef<HTMLElement>('listRef')
+const { isVisible, scrollToBottom } = useScrollToBottom(listRef)
 </script>

--- a/src/components/ScrollToBottomButton.vue
+++ b/src/components/ScrollToBottomButton.vue
@@ -1,39 +1,99 @@
 <template>
   <Transition
     enter-active-class="transition-all duration-200 ease-out"
+    enter-from-class="opacity-0 translate-y-2"
+    enter-to-class="opacity-100 translate-y-0"
     leave-active-class="transition-all duration-150 ease-in"
-    enter-from-class="opacity-0 translate-y-2 scale-90"
-    enter-to-class="opacity-100 translate-y-0 scale-100"
-    leave-from-class="opacity-100 translate-y-0 scale-100"
-    leave-to-class="opacity-0 translate-y-2 scale-90"
+    leave-from-class="opacity-100 translate-y-0"
+    leave-to-class="opacity-0 translate-y-2"
   >
     <button
       v-if="isVisible"
       type="button"
       aria-label="Scroll to bottom"
       data-testid="scroll-to-bottom-button"
-      class="
-        absolute bottom-4 right-4 z-10
-        inline-flex items-center justify-center
-        w-8 h-8 min-w-[44px] min-h-[44px]
-        rounded-full
-        bg-panel border border-borderMuted
-        text-subtleText
-        shadow-md
-        cursor-pointer
-        transition-colors transition-transform duration-150
-        hover:text-deepText hover:bg-borderMuted/20 hover:brightness-105
-        active:brightness-95 active:scale-95
-        focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent
-      "
-      @click="$emit('click')"
+      class="fixed z-40 flex items-center justify-center rounded-full border border-borderMuted bg-panel text-subtleText shadow-lg backdrop-blur-sm transition-colors hover:bg-borderMuted/60 hover:text-deepText active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      :style="buttonStyle"
+      @click="scrollToBottom"
     >
-      <i class="i-ri:arrow-down-line text-base" />
+      <i class="i-bi:chevron-double-down text-base" aria-hidden="true" />
     </button>
   </Transition>
 </template>
 
 <script setup lang="ts">
-defineProps<{ isVisible: boolean }>()
-defineEmits(['click'])
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+
+interface ScrollToBottomButtonProps {
+  scrollEl?: HTMLElement | null
+  bottomOffsetPx?: number
+  rightOffsetPx?: number
+  showAfterPx?: number
+  hideWithinPx?: number
+}
+
+const props = withDefaults(defineProps<ScrollToBottomButtonProps>(), {
+  scrollEl: null,
+  bottomOffsetPx: 16,
+  rightOffsetPx: 16,
+  showAfterPx: 120,
+  hideWithinPx: 40,
+})
+
+const isVisible = ref(false)
+
+function getTarget(): HTMLElement | Window {
+  return props.scrollEl ?? window
+}
+
+function getScrollMetrics() {
+  if (props.scrollEl) {
+    const el = props.scrollEl
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }
+  }
+  return {
+    scrollTop: window.scrollY,
+    scrollHeight: document.documentElement.scrollHeight,
+    clientHeight: window.innerHeight,
+  }
+}
+
+function updateVisibility() {
+  const { scrollTop, scrollHeight, clientHeight } = getScrollMetrics()
+  const distanceFromBottom = scrollHeight - scrollTop - clientHeight
+  isVisible.value = scrollTop > props.showAfterPx && distanceFromBottom > props.hideWithinPx
+}
+
+function scrollToBottom() {
+  if (props.scrollEl) {
+    props.scrollEl.scrollTo({ top: props.scrollEl.scrollHeight, behavior: 'smooth' })
+  } else {
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' })
+  }
+}
+
+const buttonStyle = computed(() => ({
+  bottom: `max(env(safe-area-inset-bottom, 0px), ${props.bottomOffsetPx}px)`,
+  right: `${props.rightOffsetPx}px`,
+  width: '2.75rem',
+  height: '2.75rem',
+  minWidth: '44px',
+  minHeight: '44px',
+}))
+
+let _target: HTMLElement | Window | null = null
+
+onMounted(() => {
+  _target = getTarget()
+  _target.addEventListener('scroll', updateVisibility, { passive: true })
+  updateVisibility()
+})
+
+onUnmounted(() => {
+  _target?.removeEventListener('scroll', updateVisibility)
+})
 </script>

--- a/src/components/ScrollToBottomButton.vue
+++ b/src/components/ScrollToBottomButton.vue
@@ -1,0 +1,39 @@
+<template>
+  <Transition
+    enter-active-class="transition-all duration-200 ease-out"
+    leave-active-class="transition-all duration-150 ease-in"
+    enter-from-class="opacity-0 translate-y-2 scale-90"
+    enter-to-class="opacity-100 translate-y-0 scale-100"
+    leave-from-class="opacity-100 translate-y-0 scale-100"
+    leave-to-class="opacity-0 translate-y-2 scale-90"
+  >
+    <button
+      v-if="isVisible"
+      type="button"
+      aria-label="Scroll to bottom"
+      data-testid="scroll-to-bottom-button"
+      class="
+        absolute bottom-4 right-4 z-10
+        inline-flex items-center justify-center
+        w-8 h-8 min-w-[44px] min-h-[44px]
+        rounded-full
+        bg-panel border border-borderMuted
+        text-subtleText
+        shadow-md
+        cursor-pointer
+        transition-colors transition-transform duration-150
+        hover:text-deepText hover:bg-borderMuted/20 hover:brightness-105
+        active:brightness-95 active:scale-95
+        focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent
+      "
+      @click="$emit('click')"
+    >
+      <i class="i-ri:arrow-down-line text-base" />
+    </button>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+defineProps<{ isVisible: boolean }>()
+defineEmits(['click'])
+</script>

--- a/src/components/ScrollToBottomButton.vue
+++ b/src/components/ScrollToBottomButton.vue
@@ -25,7 +25,7 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 
 interface ScrollToBottomButtonProps {
-  scrollEl?: HTMLElement | null
+  scrollEl?: HTMLElement
   bottomOffsetPx?: number
   rightOffsetPx?: number
   showAfterPx?: number
@@ -33,7 +33,6 @@ interface ScrollToBottomButtonProps {
 }
 
 const props = withDefaults(defineProps<ScrollToBottomButtonProps>(), {
-  scrollEl: null,
   bottomOffsetPx: 16,
   rightOffsetPx: 16,
   showAfterPx: 120,
@@ -85,15 +84,13 @@ const buttonStyle = computed(() => ({
   minHeight: '44px',
 }))
 
-let _target: HTMLElement | Window | null = null
-
 onMounted(() => {
-  _target = getTarget()
-  _target.addEventListener('scroll', updateVisibility, { passive: true })
+  const target = getTarget()
+  target.addEventListener('scroll', updateVisibility, { passive: true })
   updateVisibility()
-})
 
-onUnmounted(() => {
-  _target?.removeEventListener('scroll', updateVisibility)
+  onUnmounted(() => {
+    target.removeEventListener('scroll', updateVisibility)
+  })
 })
 </script>

--- a/src/components/ScrollToBottomButton.vue
+++ b/src/components/ScrollToBottomButton.vue
@@ -14,7 +14,7 @@
       data-testid="scroll-to-bottom-button"
       class="fixed z-40 flex items-center justify-center rounded-full border border-borderMuted bg-panel text-subtleText shadow-lg backdrop-blur-sm transition-colors hover:bg-borderMuted/60 hover:text-deepText active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
       :style="buttonStyle"
-      @click="scrollToBottom"
+      @click="emit('click')"
     >
       <i class="i-bi:chevron-double-down text-base" aria-hidden="true" />
     </button>
@@ -22,58 +22,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { computed } from 'vue'
 
 interface ScrollToBottomButtonProps {
-  scrollEl?: HTMLElement
+  isVisible: boolean
   bottomOffsetPx?: number
   rightOffsetPx?: number
-  showAfterPx?: number
-  hideWithinPx?: number
 }
 
 const props = withDefaults(defineProps<ScrollToBottomButtonProps>(), {
   bottomOffsetPx: 16,
   rightOffsetPx: 16,
-  showAfterPx: 120,
-  hideWithinPx: 40,
 })
 
-const isVisible = ref(false)
-
-function getTarget(): HTMLElement | Window {
-  return props.scrollEl ?? window
-}
-
-function getScrollMetrics() {
-  if (props.scrollEl) {
-    const el = props.scrollEl
-    return {
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-      clientHeight: el.clientHeight,
-    }
-  }
-  return {
-    scrollTop: window.scrollY,
-    scrollHeight: document.documentElement.scrollHeight,
-    clientHeight: window.innerHeight,
-  }
-}
-
-function updateVisibility() {
-  const { scrollTop, scrollHeight, clientHeight } = getScrollMetrics()
-  const distanceFromBottom = scrollHeight - scrollTop - clientHeight
-  isVisible.value = scrollTop > props.showAfterPx && distanceFromBottom > props.hideWithinPx
-}
-
-function scrollToBottom() {
-  if (props.scrollEl) {
-    props.scrollEl.scrollTo({ top: props.scrollEl.scrollHeight, behavior: 'smooth' })
-  } else {
-    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' })
-  }
-}
+const emit = defineEmits<{ click: [] }>()
 
 const buttonStyle = computed(() => ({
   bottom: `max(env(safe-area-inset-bottom, 0px), ${props.bottomOffsetPx}px)`,
@@ -83,14 +45,4 @@ const buttonStyle = computed(() => ({
   minWidth: '44px',
   minHeight: '44px',
 }))
-
-onMounted(() => {
-  const target = getTarget()
-  target.addEventListener('scroll', updateVisibility, { passive: true })
-  updateVisibility()
-
-  onUnmounted(() => {
-    target.removeEventListener('scroll', updateVisibility)
-  })
-})
 </script>

--- a/src/components/SearchResultsDropdown.vue
+++ b/src/components/SearchResultsDropdown.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     ref="dropdownRef"
+    role="listbox"
     aria-label="Search results dropdown"
     class="absolute top-14 left-3 right-4 bg-panel border border-borderMuted rounded-lg shadow-lg z-50 max-h-64 overflow-y-auto"
   >
@@ -23,14 +24,18 @@
       </div>
       <div v-else>
         <div
+          role="status"
+          aria-live="polite"
           class="px-3 py-2 text-xs text-subtleText border-b border-borderMuted"
-          aria-label="Search result count"
         >
           {{ results.length }} {{ results.length === 1 ? 'result' : 'results' }}
         </div>
         <div
           v-for="(result, index) in results"
           :key="getResultKey(result, index)"
+          role="option"
+          :tabindex="0"
+          :aria-selected="index === highlightedIndex"
           :data-result-type="result.resultType"
           :class="[
             'p-3 cursor-pointer border-b border-borderMuted last:border-b-0 transition-colors',
@@ -38,6 +43,8 @@
           ]"
           @click="handleResultClick(result)"
           @mouseenter="handleResultHover(index)"
+          @keydown.enter.prevent="handleResultClick(result)"
+          @keydown.space.prevent="handleResultClick(result)"
         >
           <slot
             name="result"
@@ -48,6 +55,7 @@
               <i
                 :class="getResultIcon(result)"
                 class="text-accent mt-1 flex-shrink-0"
+                aria-hidden="true"
               />
               <div class="flex-1 min-w-0">
                 <div class="text-xs text-subtleText mb-1">
@@ -107,11 +115,11 @@ const emit = defineEmits<SearchResultsDropdownEmits<T>>()
 
 const dropdownRef = ref<HTMLElement>()
 
-const handleResultClick = (result: T) => {
+function handleResultClick(result: T) {
   emit('result-click', result)
 }
 
-const handleResultHover = (index: number) => {
+function handleResultHover(index: number) {
   emit('result-hover', index)
 }
 

--- a/src/composables/use-scroll-to-bottom.ts
+++ b/src/composables/use-scroll-to-bottom.ts
@@ -1,0 +1,39 @@
+import { onMounted, onUnmounted, ref, type Ref } from 'vue'
+
+const SCROLL_THRESHOLD_PX = 120
+const AT_BOTTOM_TOLERANCE_PX = 24
+
+export function useScrollToBottom(scrollContainer: Ref<HTMLElement | undefined>) {
+  const isVisible = ref(false)
+
+  function updateVisibility() {
+    const el = scrollContainer.value
+    if (!el) return
+
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
+    const hasScrolledEnough = el.scrollTop > SCROLL_THRESHOLD_PX
+    const isAtBottom = distanceFromBottom <= AT_BOTTOM_TOLERANCE_PX
+
+    isVisible.value = hasScrolledEnough && !isAtBottom
+  }
+
+  function scrollToBottom() {
+    const el = scrollContainer.value
+    if (!el) return
+
+    el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
+  }
+
+  onMounted(() => {
+    const el = scrollContainer.value
+    if (!el) return
+    el.addEventListener('scroll', updateVisibility, { passive: true })
+    updateVisibility()
+  })
+
+  onUnmounted(() => {
+    scrollContainer.value?.removeEventListener('scroll', updateVisibility)
+  })
+
+  return { isVisible, scrollToBottom, updateVisibility }
+}

--- a/src/composables/use-scroll-to-bottom.ts
+++ b/src/composables/use-scroll-to-bottom.ts
@@ -11,16 +11,12 @@ export function useScrollToBottom(scrollContainer: Ref<HTMLElement | undefined>)
     if (!el) return
 
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight
-    const hasScrolledEnough = el.scrollTop > SCROLL_THRESHOLD_PX
-    const isAtBottom = distanceFromBottom <= AT_BOTTOM_TOLERANCE_PX
-
-    isVisible.value = hasScrolledEnough && !isAtBottom
+    isVisible.value = el.scrollTop > SCROLL_THRESHOLD_PX && distanceFromBottom > AT_BOTTOM_TOLERANCE_PX
   }
 
   function scrollToBottom() {
     const el = scrollContainer.value
     if (!el) return
-
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' })
   }
 
@@ -31,6 +27,7 @@ export function useScrollToBottom(scrollContainer: Ref<HTMLElement | undefined>)
     updateVisibility()
   })
 
+  // Top-level — NOT inside onMounted. Nested onUnmounted is a Vue no-op.
   onUnmounted(() => {
     scrollContainer.value?.removeEventListener('scroll', updateVisibility)
   })

--- a/src/views/ChatView.vue
+++ b/src/views/ChatView.vue
@@ -66,7 +66,8 @@
       <!-- Messages -->
       <div
         v-if="messages.length > 0"
-        class="flex flex-col flex-1 min-h-0 w-full overflow-y-auto"
+        ref="messagesScrollRef"
+        class="relative flex flex-col flex-1 min-h-0 w-full overflow-y-auto"
       >
         <div class="flex flex-col gap-0">
           <ChatMessage
@@ -81,6 +82,11 @@
             @rewrite="handleRewriteMessage"
           />
         </div>
+
+        <ScrollToBottomButton
+          :is-visible="isScrollToBottomVisible"
+          @click="scrollToBottom"
+        />
       </div>
 
       <!-- Message list input section -->
@@ -130,13 +136,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import ChatMessage from '@/components/ChatMessage.vue'
 import BaseEmptyState from '@/components/BaseEmptyState.vue'
 import BaseSpinner from '@/components/BaseSpinner.vue'
 import SubscriptionModal from '@/components/SubscriptionModal.vue'
 import ChatInputBlock from '@/components/ChatInputBlock.vue'
+import ScrollToBottomButton from '@/components/ScrollToBottomButton.vue'
 import { useChat } from '@/composables/use-chat'
+import { useScrollToBottom } from '@/composables/use-scroll-to-bottom'
 
 defineOptions({ name: 'ChatView' })
 
@@ -177,9 +185,18 @@ const {
 
 const chatInputTopRef = ref()
 const chatInputBottomRef = ref()
+const messagesScrollRef = ref<HTMLElement>()
+
+const { isVisible: isScrollToBottomVisible, scrollToBottom, updateVisibility } = useScrollToBottom(messagesScrollRef)
 
 // Sync the focusable ref
 watch([chatInputTopRef, chatInputBottomRef], () => {
   chatInputRef.value = chatInputTopRef.value || chatInputBottomRef.value
 })
+
+// Re-check scroll visibility when streaming appends new content
+watch(
+  () => messages.value.length,
+  () => nextTick(updateVisibility),
+)
 </script>


### PR DESCRIPTION
## Summary

Final polish commit (`b56827d`) on this branch was committed after the related squash merge and is **not in `dev`**.

### Changes ahead of dev
- `BaseModal.vue` — restore confirm/cancel emits, clean up structure (+45/-27)
- `MessageList.vue` — minor wiring fix (+6/-1)
- `ScrollToBottomButton.vue` — undefined → null on prop, remove module-level mutable state (+4/-52)
- `use-scroll-to-bottom.ts` — move `onUnmounted` to top-level, delegate scroll logic to composable (+2/-5)

## Verification

Confirmed via tip commit diff (`b56827d`) — this is the final fix commit from May 11 05:41, 1 minute after the squash merge of the earlier work.