### PR TITLE
fix: header visibility and chat input styling in offline mode

- Provide mock session in offline mode to ensure header visibility.
- Fix router redirects to /chat in offline mode.
- Guard VS Code context store initialization and side effects.
- Redesign ChatInput with a cyberpunk themed container.
- Fix textarea styling in BaseTextField and ChatInput.
- Fix env-validator unit tests.
- Ensure pnpm commands in .woodpecker.yml use input redirection.

Co-authored-by: simwai <16225108+simwai@users.noreply.github.com>

### DIFF
--- a/apply_fix.py
+++ b/apply_fix.py
@@ -1,0 +1,66 @@
+import sys
+
+filepath = 'src/composables/use-app-logic.ts'
+with open(filepath, 'r') as f:
+    content = f.read()
+
+search1 = """  onMounted(async () => {
+    supabase.auth.onAuthStateChange((event, session) => {
+      handleAuthStateChange(event, session)
+    })"""
+
+replace1 = """  onMounted(async () => {
+    if (isOfflineMode()) {
+      session.value = {
+        access_token: 'offline-token',
+        user: {
+          id: 'offline-user',
+          email: 'offline@local',
+          app_metadata: {},
+          user_metadata: { full_name: 'Offline User' },
+          aud: 'authenticated',
+          created_at: new Date().toISOString(),
+        } as any,
+        expires_in: 3600,
+        token_type: 'bearer',
+      }
+    }
+
+    supabase.auth.onAuthStateChange((event, session) => {
+      handleAuthStateChange(event, session)
+    })"""
+
+search2 = """    const { data, error } = await supabase.auth.getSession()
+    if (data.session) void loadSettings()
+
+    if (error) {
+      logger.error('Failed to retrieve auth session, clearing stale data', { error })
+      await supabase.auth.signOut()
+      return
+    }
+
+    session.value = data.session
+  })"""
+
+replace2 = """    if (isOfflineMode()) {
+      void loadSettings()
+      return
+    }
+
+    const { data, error } = await supabase.auth.getSession()
+    if (data.session) void loadSettings()
+
+    if (error) {
+      logger.error('Failed to retrieve auth session, clearing stale data', { error })
+      await supabase.auth.signOut()
+      return
+    }
+
+    session.value = data.session
+  })"""
+
+content = content.replace(search1, replace1)
+content = content.replace(search2, replace2)
+
+with open(filepath, 'w') as f:
+    f.write(content)

--- a/src/composables/use-app-logic.ts
+++ b/src/composables/use-app-logic.ts
@@ -1,4 +1,5 @@
 import { ref, watch, onMounted, type Ref } from 'vue'
+import { isOfflineMode } from '@/env-validator'
 import { useRouter } from 'vue-router'
 import { useEventListener } from '@vueuse/core'
 import type { Session, AuthChangeEvent } from '@supabase/supabase-js'
@@ -85,6 +86,22 @@ export function useAppLogic() {
   }
 
   onMounted(async () => {
+    if (isOfflineMode()) {
+      session.value = {
+        access_token: 'offline-token',
+        user: {
+          id: 'offline-user',
+          email: 'offline@local',
+          app_metadata: {},
+          user_metadata: { full_name: 'Offline User' },
+          aud: 'authenticated',
+          created_at: new Date().toISOString(),
+        } as any,
+        expires_in: 3600,
+        token_type: 'bearer',
+      }
+    }
+
     supabase.auth.onAuthStateChange((event, session) => {
       handleAuthStateChange(event, session)
     })
@@ -100,6 +117,11 @@ export function useAppLogic() {
       },
       { deep: true }
     )
+
+    if (isOfflineMode()) {
+      void loadSettings()
+      return
+    }
 
     const { data, error } = await supabase.auth.getSession()
     if (data.session) void loadSettings()

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -60,7 +60,7 @@ export function createAppRouter(supabase: SupabaseClient): Router {
   router.beforeEach(async (to) => {
     if (offline) {
       if (
-        to.path === '/' ||
+        to.path === '/' || to.path === '' ||
         to.path === '/login' ||
         to.path === '/reset-password' ||
         to.path === '/auth/callback'
@@ -77,7 +77,7 @@ export function createAppRouter(supabase: SupabaseClient): Router {
 
     if (
       !to.meta.requiresAuth &&
-      (to.path === '/' || to.path === '/login' || to.path === '/auth/callback') &&
+      (to.path === '/' || to.path === '' || to.path === '/login' || to.path === '/auth/callback') &&
       session
     ) {
       return { path: '/chat' }

--- a/src/services/vs-code-bridge.ts
+++ b/src/services/vs-code-bridge.ts
@@ -26,7 +26,7 @@ export class VsCodeBridge {
   post(message: object): void {
     const apiResult = getVsCodeApi()
     if (apiResult.isErr()) {
-      logger.warn('Cannot post message to VS Code', {
+      logger.debug('Cannot post message to VS Code', {
         messageType: (message as { type?: string }).type,
         error: apiResult.error,
       })

--- a/src/stores/use-vs-code-context-store.ts
+++ b/src/stores/use-vs-code-context-store.ts
@@ -315,15 +315,17 @@ export const useVsCodeContextStore = defineStore('vsCodeContext', () => {
     return result
   }
 
-  useEventListener(window, 'message', handleVsCodeMessage)
+  if (isInVsCode.value) {
+    useEventListener(window, 'message', handleVsCodeMessage)
 
-  const notifySidebarReady = (): void => {
-    const message: SidebarReadyMessage = { type: 'sidebar.ready' }
-    bridge.post(message)
+    const notifySidebarReady = (): void => {
+      const message: SidebarReadyMessage = { type: 'sidebar.ready' }
+      bridge.post(message)
+    }
+
+    notifySidebarReady()
+    void rebuildPinnedItems()
   }
-
-  notifySidebarReady()
-  void rebuildPinnedItems()
 
   return {
     // state / flags

--- a/tests/env-validator.test.ts
+++ b/tests/env-validator.test.ts
@@ -10,14 +10,11 @@ const env: Writeable<EnvConfigType> = import.meta.env as unknown as Writeable<En
 describe('validateEnvConfig()', () => {
   const originalEnv = { ...env }
   const validEnv = {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     VITE_NODE_ENV: 'development',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     VITE_SUPABASE_URL: 'https://example.supabase.co',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     VITE_SUPABASE_ANON_KEY: 'key123',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     VITE_SOCKET_URL: 'https://socket.example.com',
+    VITE_OFFLINE_MODE: 'false',
   }
 
   beforeAll(() => {
@@ -25,58 +22,50 @@ describe('validateEnvConfig()', () => {
   })
 
   afterEach(() => {
+    for (const key in env) {
+        delete (env as any)[key]
+    }
     Object.assign(env, originalEnv)
   })
 
   it('returns Ok with valid env config', () => {
     const result = validateEnvConfig()
-
     expect(result.isOk()).toBe(true)
   })
 
   describe('validation errors', () => {
-    const errorCases = [
-      {
-        name: 'VITE_SUPABASE_URL is invalid',
-        setup: () => {
-          env.VITE_SUPABASE_URL = 'not-a-url'
-        },
-        expectedError: 'VITE_SUPABASE_URL',
-      },
-      {
-        name: 'VITE_SOCKET_URL is invalid',
-        setup: () => {
-          env.VITE_SOCKET_URL = 'also-not-a-url'
-        },
-        expectedError: 'VITE_SOCKET_URL',
-      },
-      {
-        name: 'VITE_SUPABASE_ANON_KEY is missing',
-        setup: () => {
-          delete env.VITE_SUPABASE_ANON_KEY
-        },
-        expectedError: 'VITE_SUPABASE_ANON_KEY',
-      },
-    ]
-
-    test.each(errorCases)('returns Err when $name', ({ setup, expectedError }) => {
-      setup()
-
+    test('returns Err when VITE_SUPABASE_URL is invalid', () => {
+      (env as any).VITE_SUPABASE_URL = 'not-a-url'
       const result = validateEnvConfig()
-
       expect(result.isErr()).toBe(true)
       if (result.isErr()) {
-        expect(result.error).toBeInstanceOf(Error)
-        expect(result.error.message).toContain(expectedError)
+        expect(result.error.message).toContain('VITE_SUPABASE_URL')
+      }
+    })
+
+    test('returns Err when VITE_SOCKET_URL is invalid', () => {
+      (env as any).VITE_SOCKET_URL = 'also-not-a-url'
+      const result = validateEnvConfig()
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.message).toContain('VITE_SOCKET_URL')
+      }
+    })
+
+    test('returns Err when VITE_SUPABASE_ANON_KEY is missing and offline mode is false', () => {
+      (env as any).VITE_OFFLINE_MODE = 'false';
+      delete (env as any).VITE_SUPABASE_ANON_KEY;
+      const result = validateEnvConfig()
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error.message).toContain('VITE_SUPABASE_ANON_KEY')
       }
     })
 
     it('returns Err when multiple fields are invalid', () => {
-      env.VITE_SUPABASE_URL = 'bad-url'
-      env.VITE_SOCKET_URL = 'also-bad'
-
+      (env as any).VITE_SUPABASE_URL = 'bad-url';
+      (env as any).VITE_SOCKET_URL = 'also-bad';
       const result = validateEnvConfig()
-
       expect(result.isErr()).toBe(true)
     })
   })


### PR DESCRIPTION
## 📝 Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## 🎞️ Type of change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## ✅ Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with `pnpm test`
