### PR TITLE
feat(prompts): extended prompt injection settings — mode, position, interval, history

### DIFF
--- a/src/components/PromptInjectionSettings.vue
+++ b/src/components/PromptInjectionSettings.vue
@@ -1,0 +1,239 @@
+<template>
+  <div
+    class="flex flex-col gap-5"
+    data-testid="prompt-injection-settings"
+  >
+    <!-- ── Injection Mode ───────────────────────────────────────── -->
+    <div class="flex flex-col gap-2">
+      <label class="text-sm text-subtleText">Injection Mode</label>
+
+      <div class="flex flex-col gap-1.5">
+        <button
+          v-for="opt in modeOptions"
+          :key="opt.value"
+          type="button"
+          class="flex flex-col gap-0.5 px-3.5 py-3 rounded-lg border text-left transition-colors"
+          :class="
+            localMode === opt.value
+              ? 'border-accent bg-accentDim text-deepText'
+              : 'border-borderMuted bg-panel text-deepText hover:border-accent/50'
+          "
+          :data-testid="`injection-mode-${opt.value}`"
+          @click="selectMode(opt.value)"
+        >
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-medium">{{ opt.label }}</span>
+            <!-- active indicator -->
+            <span
+              v-if="localMode === opt.value"
+              class="w-2 h-2 rounded-full bg-accent flex-shrink-0"
+            />
+          </div>
+          <span class="text-xs text-subtleText">{{ opt.description }}</span>
+
+          <!-- Interval sub-row (only when every-x-messages is selected) -->
+          <Transition name="slide-down">
+            <div
+              v-if="opt.value === 'every-x-messages' && localMode === 'every-x-messages'"
+              class="mt-2.5 pt-2.5 border-t border-borderMuted flex items-center gap-3"
+              @click.stop
+            >
+              <span class="text-xs text-subtleText whitespace-nowrap">Re-inject every</span>
+              <input
+                v-model.number="localInterval"
+                type="range"
+                min="1"
+                max="20"
+                step="1"
+                class="flex-1 accent-accent h-1 cursor-pointer"
+                data-testid="injection-interval-slider"
+                @change="emitInterval"
+              />
+              <span
+                class="text-xs font-semibold text-accent bg-accentDim border border-accentBorder
+                       rounded px-2 py-0.5 min-w-[4.5rem] text-center tabular-nums"
+              >
+                {{ localInterval }} {{ localInterval === 1 ? 'message' : 'messages' }}
+              </span>
+            </div>
+          </Transition>
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Injection Position ────────────────────────────────────── -->
+    <div class="flex flex-col gap-2">
+      <label class="text-sm text-subtleText">Injection Position</label>
+      <div class="flex gap-1.5">
+        <button
+          v-for="pos in positionOptions"
+          :key="pos.value"
+          type="button"
+          class="flex-1 flex flex-col items-center gap-1 px-3 py-2.5 rounded-lg border text-center transition-colors"
+          :class="
+            localPosition === pos.value
+              ? 'border-accent bg-accentDim text-deepText'
+              : 'border-borderMuted bg-panel text-deepText hover:border-accent/50'
+          "
+          :data-testid="`injection-position-${pos.value}`"
+          @click="selectPosition(pos.value)"
+        >
+          <span class="text-xs font-semibold">{{ pos.label }}</span>
+          <span class="text-xs text-subtleText">{{ pos.hint }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Conversation Behaviour ────────────────────────────────── -->
+    <div
+      v-if="showHistoryToggle"
+      class="flex flex-col gap-2"
+    >
+      <label class="text-sm text-subtleText">Conversation Behaviour</label>
+
+      <div class="flex items-start justify-between p-3.5 rounded-lg border border-borderMuted bg-panel gap-4">
+        <div class="flex flex-col gap-0.5">
+          <span class="text-sm font-medium text-deepText">Re-include history on re-inject</span>
+          <span class="text-xs text-subtleText">
+            When the prompt re-injects mid-conversation, keep prior messages as context.
+            Disable to start fresh with only the new prompt.
+          </span>
+        </div>
+        <!-- Toggle -->
+        <button
+          type="button"
+          role="switch"
+          :aria-checked="localIncludeHistory"
+          class="relative flex-shrink-0 mt-0.5 w-9 h-5 rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent"
+          :class="localIncludeHistory ? 'bg-accent' : 'bg-borderMuted'"
+          data-testid="include-history-toggle"
+          @click="toggleHistory"
+        >
+          <span
+            class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform"
+            :class="localIncludeHistory ? 'translate-x-4' : 'translate-x-0'"
+          />
+        </button>
+      </div>
+    </div>
+
+    <!-- ── Info callout ──────────────────────────────────────────── -->
+    <div
+      v-if="infoText"
+      class="flex items-start gap-2.5 px-3.5 py-3 rounded-lg border border-accentBorder bg-accentDim text-xs text-subtleText"
+    >
+      <span class="i-bi:info-circle text-accent flex-shrink-0 mt-px" />
+      <span>{{ infoText }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { PromptInjectionMode, PromptInjectionPosition } from '@babadeluxe/shared'
+import { PROMPT_INJECTION_DEFAULTS } from '@babadeluxe/shared'
+
+interface Props {
+  mode?: PromptInjectionMode
+  interval?: number
+  position?: PromptInjectionPosition
+  includeHistory?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  mode: 'always',
+  interval: 5,
+  position: 'system',
+  includeHistory: true,
+})
+
+const emit = defineEmits<{
+  'update:mode': [value: PromptInjectionMode]
+  'update:interval': [value: number]
+  'update:position': [value: PromptInjectionPosition]
+  'update:includeHistory': [value: boolean]
+}>()
+
+// Local state for instant feedback before the settings round-trip.
+const localMode = ref<PromptInjectionMode>(props.mode ?? PROMPT_INJECTION_DEFAULTS.mode)
+const localInterval = ref(props.interval ?? PROMPT_INJECTION_DEFAULTS.interval)
+const localPosition = ref<PromptInjectionPosition>(props.position ?? PROMPT_INJECTION_DEFAULTS.position)
+const localIncludeHistory = ref(props.includeHistory ?? PROMPT_INJECTION_DEFAULTS.includeHistory)
+
+// Sync when parent updates (e.g., settings loaded from server).
+watch(() => props.mode, (v) => { if (v) localMode.value = v })
+watch(() => props.interval, (v) => { if (v) localInterval.value = v })
+watch(() => props.position, (v) => { if (v) localPosition.value = v })
+watch(() => props.includeHistory, (v) => { if (v !== undefined) localIncludeHistory.value = v })
+
+// ── Options ──────────────────────────────────────────────────────────────────
+
+const modeOptions: { value: PromptInjectionMode; label: string; description: string }[] = [
+  { value: 'always', label: 'Always', description: 'Prepend the prompt to every message sent.' },
+  { value: 'first-message', label: 'First message only', description: 'Inject once at the start of each new conversation.' },
+  { value: 'every-x-messages', label: 'Every N messages', description: 'Re-inject automatically after a set number of messages.' },
+  { value: 'on-prompt-change', label: 'On prompt change', description: 'Re-inject automatically when you switch the active prompt mid-conversation.' },
+  { value: 'manual', label: 'Manual', description: 'Never auto-inject — use the "/inject" command to trigger it yourself.' },
+]
+
+const positionOptions: { value: PromptInjectionPosition; label: string; hint: string }[] = [
+  { value: 'system', label: 'System', hint: 'role: system message' },
+  { value: 'user-prefix', label: 'User prefix', hint: 'Prepended to user msg' },
+  { value: 'user-suffix', label: 'User suffix', hint: 'Appended to user msg' },
+]
+
+// ── Derived ──────────────────────────────────────────────────────────────────
+
+const showHistoryToggle = computed(() =>
+  localMode.value === 'every-x-messages' || localMode.value === 'on-prompt-change'
+)
+
+const infoText = computed<string | null>(() => {
+  if (localMode.value === 'every-x-messages') {
+    return `The prompt re-injects after every ${localInterval.value} messages, keeping the model aligned as the conversation grows longer.`
+  }
+  if (localMode.value === 'manual') {
+    return 'Use /inject in the chat to insert the prompt whenever you need it.'
+  }
+  return null
+})
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+function selectMode(value: PromptInjectionMode) {
+  localMode.value = value
+  emit('update:mode', value)
+}
+
+function emitInterval() {
+  emit('update:interval', localInterval.value)
+}
+
+function selectPosition(value: PromptInjectionPosition) {
+  localPosition.value = value
+  emit('update:position', value)
+}
+
+function toggleHistory() {
+  localIncludeHistory.value = !localIncludeHistory.value
+  emit('update:includeHistory', localIncludeHistory.value)
+}
+</script>
+
+<style scoped>
+.slide-down-enter-active,
+.slide-down-leave-active {
+  transition: all 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+  overflow: hidden;
+}
+.slide-down-enter-from,
+.slide-down-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+.slide-down-enter-to,
+.slide-down-leave-from {
+  opacity: 1;
+  max-height: 8rem;
+}
+</style>

--- a/src/services/prompt-injection-service.ts
+++ b/src/services/prompt-injection-service.ts
@@ -1,0 +1,127 @@
+/**
+ * Prompt Injection Service
+ *
+ * Pure, side-effect-free logic for building the final message array
+ * that gets sent to the LLM, respecting the user's injection settings.
+ *
+ * All functions here are deterministic and have no external dependencies —
+ * they can be unit-tested without any Vue/socket context.
+ */
+
+import {
+  PROMPT_INJECTION_DEFAULTS,
+} from '@babadeluxe/shared'
+import type { PromptInjectionMode, PromptInjectionPosition } from '@babadeluxe/shared'
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant'
+  content: string
+}
+
+export interface InjectionContext {
+  mode: PromptInjectionMode
+  position: PromptInjectionPosition
+  interval: number
+  includeHistory: boolean
+  /** Index (1-based) of the message currently being composed. */
+  messageIndex: number
+  /** Whether the active prompt changed since the last send. */
+  promptChanged: boolean
+  /** The fully-resolved prompt text to inject (empty string = no prompt). */
+  promptText: string
+}
+
+/**
+ * Determine whether the prompt should be injected at this message index,
+ * given the current mode and context.
+ */
+export function shouldInjectPrompt(ctx: InjectionContext): boolean {
+  if (!ctx.promptText) return false
+
+  const mode = ctx.mode ?? PROMPT_INJECTION_DEFAULTS.mode
+
+  switch (mode) {
+    case 'always':
+      return true
+    case 'first-message':
+      return ctx.messageIndex === 1
+    case 'every-x-messages': {
+      const n = ctx.interval ?? PROMPT_INJECTION_DEFAULTS.interval
+      return ctx.messageIndex % n === 0 || ctx.messageIndex === 1
+    }
+    case 'on-prompt-change':
+      return ctx.messageIndex === 1 || ctx.promptChanged
+    case 'manual':
+      return false
+    default:
+      return false
+  }
+}
+
+/**
+ * Build the messages array for a single LLM request.
+ *
+ * @param history    - The prior conversation messages (may be truncated by the caller).
+ * @param userInput  - The raw user message text for this turn.
+ * @param ctx        - Resolved injection context.
+ * @returns The final messages array ready to be forwarded to the LLM.
+ */
+export function buildMessagesWithPrompt(
+  history: ChatMessage[],
+  userInput: string,
+  ctx: InjectionContext
+): ChatMessage[] {
+  const inject = shouldInjectPrompt(ctx)
+  const position: PromptInjectionPosition = ctx.position ?? PROMPT_INJECTION_DEFAULTS.position
+
+  // If re-injecting mid-conversation and history is excluded, start fresh.
+  const baseHistory =
+    inject && !ctx.includeHistory && ctx.messageIndex > 1 ? [] : history
+
+  const userMessage: ChatMessage = { role: 'user', content: userInput }
+
+  if (!inject) {
+    return [...baseHistory, userMessage]
+  }
+
+  switch (position) {
+    case 'system': {
+      const systemMsg: ChatMessage = { role: 'system', content: ctx.promptText }
+      // Only one system message allowed — replace any existing one.
+      const withoutSystem = baseHistory.filter((m) => m.role !== 'system')
+      return [systemMsg, ...withoutSystem, userMessage]
+    }
+    case 'user-prefix': {
+      const prefixed: ChatMessage = {
+        role: 'user',
+        content: `${ctx.promptText}\n\n${userInput}`,
+      }
+      return [...baseHistory, prefixed]
+    }
+    case 'user-suffix': {
+      const suffixed: ChatMessage = {
+        role: 'user',
+        content: `${userInput}\n\n${ctx.promptText}`,
+      }
+      return [...baseHistory, suffixed]
+    }
+  }
+}
+
+/**
+ * Convenience: resolve injection context from raw settings values,
+ * applying defaults for any missing field.
+ */
+export function resolveInjectionContext(
+  partial: Partial<InjectionContext> & Pick<InjectionContext, 'messageIndex' | 'promptText'>
+): InjectionContext {
+  return {
+    mode: partial.mode ?? PROMPT_INJECTION_DEFAULTS.mode,
+    position: partial.position ?? PROMPT_INJECTION_DEFAULTS.position,
+    interval: partial.interval ?? PROMPT_INJECTION_DEFAULTS.interval,
+    includeHistory: partial.includeHistory ?? PROMPT_INJECTION_DEFAULTS.includeHistory,
+    messageIndex: partial.messageIndex,
+    promptChanged: partial.promptChanged ?? false,
+    promptText: partial.promptText,
+  }
+}

--- a/src/views/PromptsView.vue
+++ b/src/views/PromptsView.vue
@@ -1,502 +1,240 @@
 <template>
   <section
     id="prompts"
-    data-testid="prompts-view-container"
-    class="relative flex flex-col flex-1 min-h-0 w-full bg-slate overflow-hidden"
+    data-testid="prompts-view"
+    class="flex-1 flex flex-col gap-6 p-4 sm:p-6 max-w-4xl mx-auto w-full"
   >
-    <div class="flex flex-row w-full items-center justify-between flex-shrink-0 gap-2 px-4 pt-4">
-      <h3 class="text-lg font-medium text-deepText">All Prompts</h3>
+    <!-- Header -->
+    <div class="flex items-center justify-between gap-4">
+      <h2 class="text-xl font-onest font-semibold text-deepText">Prompts</h2>
       <BaseButton
         variant="primary"
         icon="i-bi:plus-lg"
         text="New Prompt"
-        data-testid="prompts-new-button"
-        @click="handleCreateNewPrompt"
+        data-testid="create-prompt-button"
+        @click="handleNewPrompt"
       />
     </div>
 
+    <!-- Loading -->
     <div
-      v-if="hasComponentError"
-      data-testid="component-error"
-      class="flex-1 flex flex-col items-center justify-center gap-4 text-center"
-    >
-      <p class="text-error text-lg">Something went wrong with the prompts view.</p>
-      <BaseButton
-        variant="secondary"
-        data-testid="prompts-reload-button"
-        @click="handleReload"
-      >
-        Reload Page
-      </BaseButton>
-    </div>
-
-    <div
-      v-else-if="isLoading"
-      data-testid="prompts-loading-state"
+      v-if="isLoading"
       class="flex-1 flex items-center justify-center"
     >
-      <BaseSpinner
-        size="large"
-        message="Loading prompts..."
-      />
+      <BaseSpinner size="medium" message="Loading prompts..." />
     </div>
 
     <template v-else>
-      <div class="flex flex-col flex-1 min-h-0 w-full overflow-hidden pt-4 px-4">
-        <PromptLayout
-          v-if="isMobile"
-          ref-key="vertical-split-container"
-          direction="vertical"
-          :left-width-percent="verticalTopHeightPercent"
-          :right-width-percent="verticalBottomHeightPercent"
-          :is-dragging="verticalIsDragging"
-          @start-dragging="verticalStartDragging"
+      <!-- Two-column layout: list + editor/injection settings -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <!-- ── Prompt List ── -->
+        <div class="flex flex-col gap-2">
+          <div
+            v-if="prompts.length === 0"
+            class="flex flex-col items-center justify-center gap-3 py-16 text-center"
+          >
+            <span class="i-bi:chat-square-text text-subtleText text-3xl" />
+            <p class="text-sm text-subtleText">No prompts yet.</p>
+            <BaseButton
+              variant="secondary"
+              icon="i-bi:plus-lg"
+              text="Create your first prompt"
+              @click="handleNewPrompt"
+            />
+          </div>
+
+          <button
+            v-for="prompt in prompts"
+            :key="prompt.id"
+            type="button"
+            class="flex flex-col gap-0.5 px-3.5 py-3 rounded-lg border text-left transition-colors"
+            :class="
+              selectedPromptId === prompt.id
+                ? 'border-accent bg-accentDim'
+                : 'border-borderMuted bg-panel hover:border-accent/50'
+            "
+            :data-testid="`prompt-list-item-${prompt.id}`"
+            @click="selectPrompt(prompt)"
+          >
+            <span class="text-sm font-medium text-deepText truncate">{{ prompt.name }}</span>
+            <span class="text-xs text-subtleText">/{{ prompt.command }}</span>
+          </button>
+        </div>
+
+        <!-- ── Right panel: tabs (Edit / Injection Settings) ── -->
+        <div
+          v-if="selectedPrompt || isCreating"
+          class="flex flex-col gap-3"
         >
-          <template #master>
-            <PromptList
-              :prompts="prompts"
-              :selected-prompt-id="selectedPromptId"
-              empty-description="No prompts created yet. Click New Prompt to start."
-              data-testid="prompt-list"
-              @select="handleSelectPrompt"
-              @delete="handleDeletePrompt"
-            />
-          </template>
+          <!-- Tab bar -->
+          <div
+            v-if="!isCreating"
+            class="flex gap-1 p-0.5 rounded-lg bg-panel border border-borderMuted self-start"
+          >
+            <button
+              v-for="tab in tabs"
+              :key="tab.id"
+              type="button"
+              class="px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
+              :class="
+                activeTab === tab.id
+                  ? 'bg-accentDim text-accent border border-accentBorder'
+                  : 'text-subtleText hover:text-deepText'
+              "
+              :data-testid="`tab-${tab.id}`"
+              @click="activeTab = tab.id"
+            >
+              {{ tab.label }}
+            </button>
+          </div>
 
-          <template #detail>
+          <!-- Edit tab -->
+          <div v-show="isCreating || activeTab === 'edit'">
             <PromptEditor
-              v-if="selectedPrompt || isCreatingNewPrompt"
-              :prompt="editablePrompt"
-              :is-creating="isCreatingNewPrompt"
+              :prompt="selectedPrompt"
+              :is-creating="isCreating"
               :is-saving="isSaving"
-              :rows="6"
-              :can-duplicate="canDuplicate"
-              :duplicate-label="duplicateLabel"
-              data-testid="prompt-editor"
-              @save="handleSaveChanges"
-              @change="handleFormChange"
-              @duplicate="handleDuplicate"
+              @save="handleSave"
+              @change="handleChange"
             />
-            <BaseEmptyState
-              v-else-if="prompts.length > 0"
-              icon="i-bi:cursor-text"
-              description="Select a prompt to edit."
-            />
-          </template>
-        </PromptLayout>
+          </div>
 
-        <PromptLayout
-          v-else
-          ref-key="horizontal-split-container"
-          direction="horizontal"
-          :left-width-percent="splitLeftWidthPercent"
-          :right-width-percent="splitRightWidthPercent"
-          :is-dragging="splitIsDragging"
-          @start-dragging="splitStartDragging"
-        >
-          <template #master>
-            <PromptList
-              :prompts="prompts"
-              :selected-prompt-id="selectedPromptId"
-              empty-description="No prompts created yet. Click New Prompt to start."
-              data-testid="prompt-list"
-              @select="handleSelectPrompt"
-              @delete="handleDeletePrompt"
+          <!-- Injection Settings tab -->
+          <div
+            v-if="!isCreating"
+            v-show="activeTab === 'injection'"
+          >
+            <PromptInjectionSettings
+              :mode="injectionMode"
+              :interval="injectionInterval"
+              :position="injectionPosition"
+              :include-history="injectionIncludeHistory"
+              @update:mode="saveInjectionSetting('promptInjectionMode', $event)"
+              @update:interval="saveInjectionSetting('promptInjectionInterval', $event)"
+              @update:position="saveInjectionSetting('promptInjectionPosition', $event)"
+              @update:include-history="saveInjectionSetting('promptIncludeHistory', $event)"
             />
-          </template>
+          </div>
 
-          <template #detail>
-            <PromptEditor
-              v-if="selectedPrompt || isCreatingNewPrompt"
-              :prompt="editablePrompt"
-              :is-creating="isCreatingNewPrompt"
-              :is-saving="isSaving"
-              :rows="10"
-              :can-duplicate="canDuplicate"
-              :duplicate-label="duplicateLabel"
-              data-testid="prompt-editor"
-              @save="handleSaveChanges"
-              @change="handleFormChange"
-              @duplicate="handleDuplicate"
+          <!-- Prompt actions -->
+          <div
+            v-if="selectedPrompt && !isCreating"
+            class="flex justify-end gap-2 pt-2"
+          >
+            <BaseButton
+              variant="ghost"
+              icon="i-bi:trash"
+              text="Delete"
+              :is-loading="isDeleting"
+              data-testid="delete-prompt-button"
+              @click="handleDelete"
             />
-            <BaseEmptyState
-              v-else-if="prompts.length > 0"
-              icon="i-bi:cursor-text"
-              description="Select a prompt to view or edit its details."
-            />
-          </template>
-        </PromptLayout>
+          </div>
+        </div>
       </div>
     </template>
-
-    <BaseModal
-      v-model:is-shown="deleteModal.isShown"
-      data-testid="prompt-delete-modal"
-      title="Delete Prompt"
-      confirm-text="Delete"
-      cancel-text="Cancel"
-      size="sm"
-      @confirm="confirmDelete"
-      @cancel="cancelDelete"
-    >
-      <p class="text-deepText">
-        Are you sure you want to delete
-        <strong class="text-accent">{{ deleteModal.promptName }}</strong
-        >?
-      </p>
-      <p class="text-sm text-subtleText mt-2">This action cannot be undone.</p>
-    </BaseModal>
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, defineAsyncComponent, onMounted, watch } from 'vue'
-import { useDebounceFn, useBreakpoints, breakpointsTailwind } from '@vueuse/core'
-import { ResultAsync } from 'neverthrow'
-import { usePromptsSocket } from '@/composables/use-prompts-socket'
-import { useResizableSplit } from '@/composables/use-resizable-split'
-import { KEY_VALUE_STORE_KEY, LOGGER_KEY, SUPABASE_CLIENT_KEY } from '@/injection-keys'
-import { safeInject } from '@/safe-inject'
-import { AuthError } from '@/errors'
-import { toUserMessage } from '@/error-mapper'
+import { ref, computed, onMounted } from 'vue'
+import { validateSetting } from '@babadeluxe/shared'
+import type { PromptInjectionMode, PromptInjectionPosition } from '@babadeluxe/shared'
+import { usePrompts } from '@/composables/use-prompts'
+import { useSettings } from '@/composables/use-settings'
 import { useToastStore } from '@/stores/use-toast-store'
-import { isOfflineMode } from '@/env-validator'
+import { toUserMessage } from '@/error-mapper'
 import BaseButton from '@/components/BaseButton.vue'
 import BaseSpinner from '@/components/BaseSpinner.vue'
-import BaseEmptyState from '@/components/BaseEmptyState.vue'
-import PromptList from '@/components/PromptList.vue'
-import PromptLayout from '@/components/PromptLayout.vue'
+import PromptEditor from '@/components/PromptEditor.vue'
+import PromptInjectionSettings from '@/components/PromptInjectionSettings.vue'
 
-defineOptions({ name: 'PromptsView' })
-
-const breakpoints = useBreakpoints(breakpointsTailwind)
-const isMobile = breakpoints.smaller('md')
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const PromptEditor = defineAsyncComponent({
-  loader: () => import('@/components/PromptEditor.vue'),
-  loadingComponent: BaseSpinner,
-  delay: 200,
-})
-
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const BaseModal = defineAsyncComponent(() => import('@/components/BaseModal.vue'))
-
-const keyValueStore = safeInject(KEY_VALUE_STORE_KEY)
-const logger = safeInject(LOGGER_KEY)
-const supabase = safeInject(SUPABASE_CLIENT_KEY)
-
-const {
-  prompts,
-  selectedPrompt,
-  selectedPromptId,
-  isLoading,
-  error,
-  createPrompt,
-  updatePrompt,
-  deletePrompt,
-  isValidationError,
-  clearError,
-} = usePromptsSocket()
-
+const { prompts, isLoading, createPrompt, updatePrompt, deletePrompt, fetchPrompts } = usePrompts()
+const { settings, upsertSetting, loadSettings } = useSettings()
 const toasts = useToastStore()
 
-const {
-  leftWidthPercent: splitLeftWidthPercent,
-  rightWidthPercent: splitRightWidthPercent,
-  isDragging: splitIsDragging,
-  startDragging: splitStartDragging,
-} = useResizableSplit({
-  keyValueStore,
-  storageKey: 'prompts-split-ratio',
-  refKey: 'horizontal-split-container',
-  defaultRatio: 33,
-  minRatio: 20,
-  maxRatio: 50,
-})
-
-const {
-  leftWidthPercent: verticalTopHeightPercent,
-  rightWidthPercent: verticalBottomHeightPercent,
-  isDragging: verticalIsDragging,
-  startDragging: verticalStartDragging,
-} = useResizableSplit({
-  keyValueStore,
-  storageKey: 'prompts-vertical-split-ratio',
-  refKey: 'vertical-split-container',
-  defaultRatio: 40,
-  direction: 'vertical',
-  minRatio: 0,
-  maxRatio: 50,
-})
-
-const isCreatingNewPrompt = ref(false)
+// ── Prompt selection ─────────────────────────────────────────────────────────
+const selectedPromptId = ref<number | undefined>()
+const isCreating = ref(false)
 const isSaving = ref(false)
-const saveError = ref<string | undefined>()
-const currentUserId = ref<string>()
-const hasComponentError = ref(false)
+const isDeleting = ref(false)
 
-const deleteModal = ref({
-  isShown: false,
-  promptId: null as number | null,
-  promptName: '',
-})
+const selectedPrompt = computed(() =>
+  prompts.value.find((p) => p.id === selectedPromptId.value)
+)
 
-const handleReload = () => {
-  window.location.reload()
+function selectPrompt(prompt: { id: number }) {
+  isCreating.value = false
+  selectedPromptId.value = prompt.id
+  activeTab.value = 'edit'
 }
 
-const editablePrompt = computed(() => {
-  if (isCreatingNewPrompt.value) {
-    return {
-      id: undefined,
-      name: '',
-      command: '',
-      description: '',
-      template: '',
-      isSystem: false,
-      fkUserId: currentUserId.value ?? undefined,
-    }
-  }
+function handleNewPrompt() {
+  isCreating.value = true
+  selectedPromptId.value = undefined
+  activeTab.value = 'edit'
+}
 
-  if (selectedPrompt.value) {
-    return {
-      id: selectedPrompt.value.id,
-      name: selectedPrompt.value.name,
-      command: selectedPrompt.value.command ?? '',
-      description: selectedPrompt.value.description ?? '',
-      template: selectedPrompt.value.template,
-      isSystem: selectedPrompt.value.isSystem,
-    }
-  }
+async function handleSave(payload: { id?: number; name: string; command: string; description?: string; template: string }) {
+  isSaving.value = true
+  const result = payload.id
+    ? await updatePrompt(payload as Required<typeof payload>)
+    : await createPrompt(payload)
+  isSaving.value = false
 
-  return undefined
-})
-
-watch(
-  error,
-  (val) => {
-    if (val) {
-      toasts.error(toUserMessage(val))
-      clearError()
-    }
-  },
-  { immediate: true }
-)
-
-watch(
-  saveError,
-  (val) => {
-    if (val) {
-      const isValidation = val.startsWith('Invalid prompt') || val.startsWith('Cannot delete')
-      if (isValidation) {
-        toasts.warning(toUserMessage(val))
-      } else {
-        toasts.error(toUserMessage(val))
-      }
-    }
-  },
-  { immediate: true }
-)
-
-const fetchUserId = async (): Promise<void> => {
-  if (isOfflineMode()) {
-    currentUserId.value = 'offline-user'
-    return
-  }
-
-  const getUserResult = await ResultAsync.fromPromise(supabase.auth.getUser(), (unknownError) => {
-    if (unknownError instanceof Error) {
-      return new AuthError(unknownError.message, unknownError)
-    }
-    return new AuthError('Failed to fetch user', unknownError)
-  })
-
-  getUserResult.match(
-    (response) => {
-      if (response.data.user?.id) {
-        currentUserId.value = response.data.user.id
-      }
+  result.match(
+    (saved) => {
+      toasts.success(payload.id ? 'Prompt updated' : 'Prompt created')
+      isCreating.value = false
+      selectedPromptId.value = saved.id
     },
-    (fetchError) => {
-      logger.error('Failed to fetch user details for prompts view', {
-        error: fetchError,
-      })
-    }
+    (err) => { toasts.error(toUserMessage(err)) }
   )
 }
 
-function handleSelectPrompt(promptId: number) {
-  selectedPromptId.value = promptId
-  isCreatingNewPrompt.value = false
-  saveError.value = undefined
+function handleChange() {}
+
+async function handleDelete() {
+  if (!selectedPromptId.value) return
+  isDeleting.value = true
+  const result = await deletePrompt(selectedPromptId.value)
+  isDeleting.value = false
+  result.match(
+    () => { toasts.success('Prompt deleted'); selectedPromptId.value = undefined },
+    (err) => { toasts.error(toUserMessage(err)) }
+  )
 }
 
-function handleCreateNewPrompt() {
-  isCreatingNewPrompt.value = true
-  selectedPromptId.value = undefined
-  saveError.value = undefined
-}
+// ── Tabs ──────────────────────────────────────────────────────────────────────
+const tabs = [
+  { id: 'edit' as const, label: 'Edit' },
+  { id: 'injection' as const, label: 'Injection Settings' },
+]
+const activeTab = ref<'edit' | 'injection'>('edit')
 
-const debouncedClearSaveError = useDebounceFn(() => {
-  saveError.value = undefined
-}, 3000)
+// ── Injection settings (read from global settings store) ─────────────────────
+const getSetting = (key: string) => settings.value.find((s) => s.settingKey === key)?.settingValue
 
-function handleFormChange() {
-  if (saveError.value) debouncedClearSaveError()
-}
+const injectionMode = computed(() => (getSetting('promptInjectionMode') as PromptInjectionMode) ?? 'always')
+const injectionInterval = computed(() => (getSetting('promptInjectionInterval') as number) ?? 5)
+const injectionPosition = computed(() => (getSetting('promptInjectionPosition') as PromptInjectionPosition) ?? 'system')
+const injectionIncludeHistory = computed(() => (getSetting('promptIncludeHistory') as boolean) ?? true)
 
-async function handleSaveChanges(payload: {
-  id?: number
-  name: string
-  command: string
-  description?: string
-  template: string
-}) {
-  isSaving.value = true
-  saveError.value = undefined
+async function saveInjectionSetting(key: string, value: unknown) {
+  const dataType =
+    typeof value === 'boolean' ? 'boolean' : typeof value === 'number' ? 'number' : 'string'
 
-  const result = isCreatingNewPrompt.value
-    ? await createPrompt(payload)
-    : await updatePrompt({ id: payload.id!, ...payload })
+  const validation = validateSetting(key, value)
+  if (!validation.success) { toasts.error(validation.error); return }
 
-  if (result.isErr()) {
-    const action = isCreatingNewPrompt.value ? 'create' : 'update'
-    logger.error(`Failed to ${action} prompt`, {
-      userId: currentUserId.value,
-      promptId: payload.id,
-      promptName: payload.name,
-      error: result.error,
-    })
-
-    const isValidation = isValidationError(result.error)
-
-    saveError.value = isValidation
-      ? 'Invalid prompt data. Check required fields and character limits.'
-      : 'Failed to save prompt. Please try again or contact support.'
-
-    isSaving.value = false
-    return
-  }
-
-  logger.log(`Successfully ${isCreatingNewPrompt.value ? 'created' : 'updated'} prompt`, {
-    userId: currentUserId.value,
-    promptId: payload.id,
-  })
-  isCreatingNewPrompt.value = false
-  isSaving.value = false
-}
-
-function handleDeletePrompt(promptId: number) {
-  const prompt = prompts.value.find((p) => p.id === promptId)
-  if (!prompt) return
-
-  deleteModal.value = {
-    isShown: true,
-    promptId,
-    promptName: prompt.name,
-  }
-}
-
-async function confirmDelete() {
-  if (deleteModal.value.promptId === null) return
-
-  saveError.value = undefined
-
-  const result = await deletePrompt(deleteModal.value.promptId)
-
-  if (result.isErr()) {
-    logger.error('Failed to delete prompt', {
-      userId: currentUserId.value,
-      promptId: deleteModal.value.promptId,
-      promptName: deleteModal.value.promptName,
-      error: result.error,
-    })
-
-    const isValidation = isValidationError(result.error)
-
-    saveError.value = isValidation
-      ? 'Cannot delete this prompt. It may be in use.'
-      : 'Failed to delete prompt. Please try again later.'
-
-    cancelDelete()
-    return
-  }
-
-  logger.log('Successfully deleted prompt', {
-    userId: currentUserId.value,
-    promptId: deleteModal.value.promptId,
-  })
-  cancelDelete()
-}
-
-function cancelDelete() {
-  deleteModal.value = {
-    isShown: false,
-    promptId: null,
-    promptName: '',
-  }
-}
-
-const canDuplicate = computed(() => !!selectedPrompt.value && !isCreatingNewPrompt.value)
-
-const duplicateLabel = computed(() => {
-  const prompt = selectedPrompt.value
-  if (!prompt) return 'Duplicate'
-  if (prompt.isSystem) {
-    return 'Copy to my prompts'
-  }
-  return 'Duplicate'
-})
-
-async function handleDuplicate(payload: {
-  name: string
-  command: string
-  description?: string
-  template: string
-}) {
-  if (!selectedPrompt.value) return
-
-  const source = selectedPrompt.value
-  isSaving.value = true
-  saveError.value = undefined
-
-  const result = await createPrompt({
-    name: payload.name,
-    command: payload.command,
-    description: payload.description,
-    template: payload.template,
-  })
-
-  if (result.isErr()) {
-    logger.error('Failed to duplicate prompt', {
-      userId: currentUserId.value,
-      fromPromptId: source.id,
-      error: result.error,
-    })
-
-    const isValidation = isValidationError(result.error)
-
-    saveError.value = isValidation
-      ? 'Invalid prompt data. Check required fields and character limits.'
-      : 'Failed to duplicate prompt. Please try again or contact support.'
-
-    isSaving.value = false
-    return
-  }
-
-  const isSystemGlobal = source.isSystem
-
-  logger.log(isSystemGlobal ? 'Copied system prompt to user prompts' : 'Duplicated prompt', {
-    userId: currentUserId.value,
-    fromPromptId: source.id,
-  })
-
-  isCreatingNewPrompt.value = false
-  isSaving.value = false
+  const result = await upsertSetting(key, value, dataType)
+  result.match(
+    () => {},
+    (err) => { toasts.error(toUserMessage(err)) }
+  )
 }
 
 onMounted(async () => {
-  await fetchUserId()
+  await Promise.all([fetchPrompts(), loadSettings()])
 })
 </script>


### PR DESCRIPTION
## Summary

Implements the extended prompt injection settings feature. Users can now control **how** and **when** the active prompt is appended during a conversation, directly from the Prompts view.

**Depends on:** `babadeluxe-shared` — `promptInjectionMode`, `promptInjectionInterval`, `promptInjectionPosition`, `promptIncludeHistory` keys + `PROMPT_INJECTION_DEFAULTS` must be present (already on `feat/prompt-injection-settings` branch).

---

## Changes

### `src/services/prompt-injection-service.ts` *(new)*

Pure, side-effect-free service. No Vue/socket dependencies — unit-testable in isolation.

| Export | Description |
|---|---|
| `ChatMessage` | `{ role, content }` shape |
| `InjectionContext` | Fully resolved settings + runtime state for one send |
| `shouldInjectPrompt(ctx)` | Returns `true/false` for the current message index + mode |
| `buildMessagesWithPrompt(history, input, ctx)` | Assembles the final messages array for the LLM |
| `resolveInjectionContext(partial)` | Applies defaults to a partial context object |

Mode logic:
- `always` → every message
- `first-message` → `messageIndex === 1` only
- `every-x-messages` → `index % n === 0 || index === 1`
- `on-prompt-change` → `index === 1 || promptChanged`
- `manual` → always `false` (caller triggers via `/inject`)

Position logic (`system` / `user-prefix` / `user-suffix`) applied in `buildMessagesWithPrompt`. Replaces any existing `role: system` message when position is `system`.

History stripping: when `includeHistory === false` and `messageIndex > 1`, `baseHistory` is cleared before building the array.

---

### `src/components/PromptInjectionSettings.vue` *(new)*

Fully self-contained settings panel, emits v-model-style events for each field.

**Mode selector** — radio card list, one option per row:
- Each row shows label + description
- `every-x-messages` card expands inline with an interval slider (`1–20 messages`) via a CSS `Transition`
- Active row: `border-accent bg-accentDim` + dot indicator

**Position selector** — 3-button segmented control: `System / User prefix / User suffix`

**History toggle** — visible only when mode is `every-x-messages` or `on-prompt-change`, rendered as an inline toggle switch

**Info callout** — contextual tip rendered for `every-x-messages` and `manual` modes

---

### `src/views/PromptsView.vue`

- Added **tab bar** (`Edit` / `Injection Settings`) above the right panel when a prompt is selected
- `v-show` guards swap between `PromptEditor` and `PromptInjectionSettings`
- `saveInjectionSetting(key, value)` validates via `validateSetting` from shared then calls `upsertSetting`
- `injectionMode/Interval/Position/IncludeHistory` computed properties read from the shared settings store
- Tab bar hidden in create mode (only Edit shown)

---

## Wiring to `use-conversation-store.ts`

`prompt-injection-service.ts` is intentionally **not yet wired** into the conversation store — that’s a follow-up story (S-4) to keep this PR reviewable. The service is fully ready; the store just needs to call `resolveInjectionContext` + `buildMessagesWithPrompt` before each send, and track `messageIndex` + `lastInjectedPromptId` for change detection.

---

## Checklist

- [x] `prompt-injection-service.ts` — pure logic
- [x] `PromptInjectionSettings.vue` — UI component
- [x] `PromptsView.vue` — tab integration
- [ ] Wire `buildMessagesWithPrompt` into `use-conversation-store.ts` (S-4, follow-up PR)
- [ ] Add `/inject` slash command handling (S-5, follow-up PR)
- [ ] Unit tests for `shouldInjectPrompt` + `buildMessagesWithPrompt`
