### PR TITLE
fix: resolve type errors and bugs in use-settings-socket tests

### DIFF
--- a/src/composables/use-settings.ts
+++ b/src/composables/use-settings.ts
@@ -14,7 +14,7 @@ export function useSettings() {
   const { socketManagerRef } = useSocketManager()
   const db = inject(APP_DB_KEY)!
 
-  const isOffline = isOfflineMode() || import.meta.env.MODE === "test"
+  const isOffline = isOfflineMode()
   const repository: SettingsRepository = isOffline
     ? new DexieSettingsRepository(db)
     : new SocketSettingsRepository(socketManagerRef)

--- a/tests/helpers/mock-socket-manager.ts
+++ b/tests/helpers/mock-socket-manager.ts
@@ -121,7 +121,7 @@ export function createMockSocketManager(
 ) {
   const socketManager = new MockSocketManager(options)
 
-  const global = {
+  const global: any = {
     provide: {
       [SOCKET_MANAGER_KEY as symbol]: ref(socketManager),
     },

--- a/tests/use-settings-socket.test.ts
+++ b/tests/use-settings-socket.test.ts
@@ -7,7 +7,7 @@ import { nextTick, ref } from 'vue'
 import { useSettings } from '@/composables/use-settings'
 import * as emitWithTimeoutModule from '@/emit-with-timeout'
 import { mountComposable } from './helpers/mount-composable'
-import type { MockSocket } from './helpers/mock-socket-manager'
+import type { MockSocket, MockSettingsSocket } from './helpers/mock-socket-manager'
 import {
   createMockSocketManager,
   trigger as triggerSocketEvent,
@@ -86,7 +86,7 @@ const fixtures = {
     },
   },
   responses: {
-    success: (data?: unknown) => ({ success: true as const, data }),
+    success: (data?: unknown) => ({ success: true as const, data: data ?? [] }),
     error: (error?: string) => ({
       success: false as const,
       error: error ?? 'Unknown error',
@@ -105,7 +105,7 @@ function trigger<T extends keyof Root.Emission>(
 
 function mockGetAllEmit(response: unknown): void {
   vi.spyOn(emitWithTimeoutModule, 'emitWithTimeout').mockResolvedValue(
-    ok(response) as Result<unknown, Error | string>
+    ok((response as any).data) as Result<unknown, Error | string>
   )
 }
 
@@ -133,14 +133,13 @@ describe('useSettings()', () => {
   function mountSettingsSocket() {
     const { socketManager, global } = createMockSocketManager()
     settingsSocket = socketManager.settingsSocket as MockSettingsSocket
-    global.provide[APP_DB_KEY as symbol] = mockDb
 
     return mountComposable(() => useSettings(), {
       global: {
         ...global,
         provide: {
           ...global.provide,
-          [APP_DB_KEY as symbol]: { localSetting: {} }, // Mock DB even if not offline
+          [APP_DB_KEY as symbol]: mockDb, // Mock DB even if not offline
         }
       }
     })


### PR DESCRIPTION
This PR fixes the TypeScript errors and logic bugs that were preventing the `use-settings-socket.test.ts` from passing. 

Key changes:
- Added missing `MockSettingsSocket` import to `use-settings-socket.test.ts`.
- Fixed typing in `mock-socket-manager.ts` by casting `global` to `any` to allow providing mock databases under `APP_DB_KEY`.
- Removed the hardcoded `MODE === 'test'` offline override in `use-settings.ts`. This was forcing offline mode in tests, preventing the socket-based logic from being tested. Now tests can control this via `isOfflineMode()` mock.
- Refactored `mountSettingsSocket` to correctly provide the `mockDb`.
- Updated `mockGetAllEmit` and `fixtures` in tests to align with how `emitWithTimeout` extracts data from responses.

All unit tests for settings socket now pass and `pnpm type-check` is clean.

---
*PR created automatically by Jules for task [1902587707914048248](https://jules.google.com/task/1902587707914048248) started by @simwai*