### PR TITLE
feat(sync): Phase 3 & 4 — WebDAV adapter, SFTP bridge, conflict resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules/
 # Local temporary files
 *.patch
 fix_*.py
+*_patch.txt

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -88,11 +88,12 @@ export class ConflictError extends BaseError {
     public readonly backend: string,
     public readonly conversationId: number,
     public readonly localVersion: number,
-    public readonly remoteVersion: number,
+    public readonly remoteVersion?: number,
     cause?: unknown
   ) {
+    const remoteStr = remoteVersion !== undefined ? `remote v${remoteVersion}` : 'unknown remote version'
     super(
-      `[sync:${backend}] Conflict on conversation ${conversationId}: local v${localVersion} vs remote v${remoteVersion}`,
+      `[sync:${backend}] Conflict on conversation ${conversationId}: local v${localVersion} vs ${remoteStr}`,
       cause
     )
   }

--- a/src/services/vs-code-bridge.ts
+++ b/src/services/vs-code-bridge.ts
@@ -4,9 +4,9 @@ import type { Result } from 'neverthrow'
 import { err, ok } from 'neverthrow'
 import { NetworkError } from '@/errors'
 import { socketTimeoutMs } from '@/constants'
-import type { AutoContextRequest, FileContextResolveRequest } from '@/vs-code/types'
+import type { IncomingMessage } from '@/vs-code/types'
 
-type PendingResolver = (result: Result<unknown[], NetworkError>) => void
+type PendingResolver = (result: Result<IncomingMessage, NetworkError>) => void
 
 export class VsCodeBridge {
   private static _instance: VsCodeBridge
@@ -35,23 +35,23 @@ export class VsCodeBridge {
     apiResult.value.postMessage(message)
   }
 
-  async postAndAwait(
-    request: AutoContextRequest | FileContextResolveRequest,
+  async postAndAwait<T extends IncomingMessage>(
+    request: { type: string; requestId: string } & Record<string, unknown>,
     createTimeout: (cb: () => void, ms: number) => NodeJS.Timeout,
     cancelTimeout: (id: NodeJS.Timeout) => void,
     timeoutMs: number = socketTimeoutMs.vsCodeContext
-  ): Promise<Result<unknown[], NetworkError>> {
+  ): Promise<Result<T, NetworkError>> {
     const apiResult = getVsCodeApi()
-    if (apiResult.isErr()) return err(apiResult.error)
+    if (apiResult.isErr()) return err(new NetworkError(apiResult.error.message, apiResult.error))
 
     const vsCodeApi = apiResult.value
     const requestId = request.requestId
     const requestType = request.type
 
-    return await new Promise<Result<unknown[], NetworkError>>((resolve) => {
+    return await new Promise<Result<T, NetworkError>>((resolve) => {
       let didFinish = false
 
-      const finish = (result: Result<unknown[], NetworkError>) => {
+      const finish = (result: Result<T, NetworkError>) => {
         if (didFinish) return
         didFinish = true
         this._pending.delete(requestId)
@@ -70,7 +70,7 @@ export class VsCodeBridge {
 
       this._pending.set(requestId, (result) => {
         cancelTimeout(timeoutId)
-        finish(result)
+        finish(result as Result<T, NetworkError>)
       })
 
       vsCodeApi.postMessage(request)
@@ -91,6 +91,6 @@ export class VsCodeBridge {
       return
     }
 
-    resolve(ok((message as { items?: unknown[] }).items ?? []))
+    resolve(ok(message as IncomingMessage))
   }
 }

--- a/src/stores/use-vs-code-context-store.ts
+++ b/src/stores/use-vs-code-context-store.ts
@@ -114,7 +114,7 @@ export const useVsCodeContextStore = defineStore('vsCodeContext', () => {
     if (cleaned.length === 0) return ok([])
 
     const requestId = makeId()
-    const result = await bridge.postAndAwait(
+    const result = await bridge.postAndAwait<FileContextResponse>(
       { type: 'fileContext:resolve', requestId, filePaths: cleaned },
       createTimeout,
       cancelTimeout,
@@ -123,8 +123,7 @@ export const useVsCodeContextStore = defineStore('vsCodeContext', () => {
     if (result.isErr()) return err(result.error)
 
     const resolved: Array<{ filePath: string; content: string }> = []
-    for (const raw of result.value) {
-      const item = raw as { filePath?: unknown; snippet?: unknown }
+    for (const item of result.value.items ?? []) {
       if (typeof item.filePath !== 'string' || item.filePath.trim().length === 0) continue
       if (typeof item.snippet !== 'string') continue
       resolved.push({ filePath: item.filePath, content: item.snippet })
@@ -204,7 +203,7 @@ export const useVsCodeContextStore = defineStore('vsCodeContext', () => {
     }
 
     const requestId = makeId()
-    const result = await bridge.postAndAwait(
+    const result = await bridge.postAndAwait<AutoContextResponse>(
       { type: 'autoContext:request', requestId, query: trimmed },
       createTimeout,
       cancelTimeout
@@ -224,8 +223,7 @@ export const useVsCodeContextStore = defineStore('vsCodeContext', () => {
     ])
 
     const nextSuggested = new Map<string, SuggestedEntry>()
-    for (const raw of result.value) {
-      const item = raw as { filePath?: unknown; score?: unknown; matchRange?: unknown }
+    for (const item of result.value.items ?? []) {
       if (typeof item.filePath !== 'string') continue
       const cleanedPath = compact(item.filePath)
       if (!cleanedPath) continue

--- a/src/sync/conflict-resolver.ts
+++ b/src/sync/conflict-resolver.ts
@@ -1,0 +1,52 @@
+import type { SyncPayload } from '@/sync/types'
+
+export type ConflictResolution = 'use-local' | 'use-remote' | 'noop'
+
+/**
+ * Deterministic conflict resolution for single-writer sync.
+ *
+ * Resolution matrix:
+ * - Same syncVersion + same content hash → noop (idempotent upload, safe to ignore)
+ * - Local syncVersion > remote syncVersion → use-local (we're ahead; remote is stale)
+ * - Remote syncVersion > local syncVersion → use-remote (remote is newer; local is behind)
+ * - Same syncVersion but different content → use-remote (another device wrote concurrently;
+ *   remote wins to prevent split-brain — surface to user if needed in future)
+ */
+export function resolveConflict(
+  local: SyncPayload,
+  remote: SyncPayload
+): ConflictResolution {
+  if (local.syncVersion === remote.syncVersion) {
+    // Check content hash — if payloads are byte-for-byte equivalent it's a noop
+    if (_payloadHash(local) === _payloadHash(remote)) return 'noop'
+    // Same version, different content — another device wrote concurrently.
+    // Remote wins (last-write-wins by device that reached the remote first).
+    return 'use-remote'
+  }
+
+  if (local.syncVersion > remote.syncVersion) return 'use-local'
+  return 'use-remote'
+}
+
+/**
+ * Returns true when a pull result should overwrite local — i.e. when remote is newer
+ * or when local has no version yet (first sync).
+ */
+export function shouldApplyRemote(
+  localSyncVersion: number | undefined,
+  remote: SyncPayload
+): boolean {
+  if (localSyncVersion === undefined || localSyncVersion === 0) return true
+  return remote.syncVersion > localSyncVersion
+}
+
+/** Lightweight structural hash — not cryptographic, just for equality checks */
+function _payloadHash(payload: SyncPayload): string {
+  return JSON.stringify({
+    syncVersion: payload.syncVersion,
+    deviceId: payload.deviceId,
+    messagesCount: payload.messages.length,
+    lastMessageId: payload.messages.at(-1)?.id,
+    conversationUpdatedAt: (payload.conversation as { updatedAt?: string }).updatedAt,
+  })
+}

--- a/src/sync/conflict-resolver.ts
+++ b/src/sync/conflict-resolver.ts
@@ -31,6 +31,9 @@ export function resolveConflict(
 /**
  * Returns true when a pull result should overwrite local — i.e. when remote is newer
  * or when local has no version yet (first sync).
+ *
+ * @warning Callers MUST check if the conversation has pending local changes (via SyncManager._pending)
+ * before calling this, otherwise local changes might be silently overwritten by a remote pull.
  */
 export function shouldApplyRemote(
   localSyncVersion: number | undefined,

--- a/src/sync/sftp-bridge-adapter.ts
+++ b/src/sync/sftp-bridge-adapter.ts
@@ -1,4 +1,4 @@
-import { ok, err, type Result } from 'neverthrow'
+import { ok, err, type Result, ResultAsync } from 'neverthrow'
 import { SyncError, SyncAuthError } from '@/errors'
 import type { ISyncAdapter, SyncPayload, ConversationSnapshot, ConversationSnapshotForUpload } from '@/sync/types'
 import type { DeviceIdService } from '@/sync/device-id'
@@ -107,23 +107,22 @@ export class SftpBridgeAdapter implements ISyncAdapter {
     payload: Record<string, unknown>
   ): Promise<Result<T, SyncError>> {
     const requestId = crypto.randomUUID()
-    const request = { type, requestId, ...payload } as SftpRequest
+    const request = { type, requestId, ...payload }
 
-    const result = await this._bridge.postAndAwait(
-      request as Parameters<typeof this._bridge.postAndAwait>[0],
+    return this._bridge.postAndAwait<any>(
+      request,
       (cb, ms) => setTimeout(cb, ms) as unknown as NodeJS.Timeout,
       (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>)
-    )
-
-    if (result.isErr()) {
-      const msg = result.error.message
-      if (msg.includes('auth') || msg.includes('Authentication')) {
-        return err(new SyncAuthError('sftp', msg))
+    ).then((result) => {
+      if (result.isErr()) {
+        const msg = result.error.message
+        if (msg.includes('auth') || msg.includes('Authentication')) {
+          return err(new SyncAuthError('sftp', msg))
+        }
+        return err(new SyncError('sftp', msg, result.error))
       }
-      return err(new SyncError('sftp', msg, result.error))
-    }
-
-    return ok(result.value as T)
+      return ok(result.value as T)
+    })
   }
 
   private _remoteDir(): string {

--- a/src/sync/sftp-bridge-adapter.ts
+++ b/src/sync/sftp-bridge-adapter.ts
@@ -1,0 +1,136 @@
+import { ok, err, type Result } from 'neverthrow'
+import { SyncError, SyncAuthError } from '@/errors'
+import type { ISyncAdapter, SyncPayload, ConversationSnapshot, ConversationSnapshotForUpload } from '@/sync/types'
+import type { DeviceIdService } from '@/sync/device-id'
+import { VsCodeBridge } from '@/services/vs-code-bridge'
+
+// ─── Message contract (webview → extension host) ────────────────────────────
+
+export type SftpRequest =
+  | { type: 'sync:sftp:push'; requestId: string; path: string; content: string }
+  | { type: 'sync:sftp:pull'; requestId: string; dirPath: string }
+  | { type: 'sync:sftp:delete'; requestId: string; path: string }
+  | { type: 'sync:sftp:test'; requestId: string }
+
+export type SftpResponse = {
+  requestId: string
+  error?: string
+  // pull response
+  files?: Array<{ path: string; content: string }>
+  // test/push/delete: just error presence signals failure
+}
+
+export type SftpAdapterConfig = {
+  host: string
+  port: number
+  username: string
+  /** Stored in VS Code SecretStorage — never in app-db */
+  privateKeyOrPassword: string
+  remotePath: string
+}
+
+const FILE_PREFIX = 'chats/'
+const FILE_EXTENSION = '.json'
+
+/**
+ * Thin postMessage shim — delegates all SFTP I/O to the VS Code extension host
+ * via VsCodeBridge. The actual ssh2-sftp-client calls live in sftp-host-service.ts.
+ *
+ * Only available when running inside VS Code. Gracefully returns SyncError when
+ * the VS Code API is not present.
+ */
+export class SftpBridgeAdapter implements ISyncAdapter {
+  readonly name = 'sftp'
+  private readonly _bridge = VsCodeBridge.getInstance()
+
+  constructor(
+    private readonly _config: SftpAdapterConfig,
+    private readonly _deviceIdService: DeviceIdService
+  ) {}
+
+  async push(payload: SyncPayload): Promise<Result<void, SyncError>> {
+    const path = this._filePath(payload.conversation.id)
+
+    if (payload.deletedAt) {
+      return this._send<void>('sync:sftp:delete', { path })
+    }
+
+    const snapshot: ConversationSnapshotForUpload = {
+      id: payload.conversation.id,
+      syncVersion: payload.syncVersion,
+      conversation: payload.conversation,
+      messages: payload.messages,
+      deviceId: payload.deviceId,
+    }
+    const content = JSON.stringify(snapshot, null, 2)
+    return this._send<void>('sync:sftp:push', { path, content })
+  }
+
+  async pull(): Promise<Result<SyncPayload[], SyncError>> {
+    const result = await this._send<{ files: Array<{ path: string; content: string }> }>(
+      'sync:sftp:pull',
+      { dirPath: this._remoteDir() }
+    )
+    if (result.isErr()) return err(result.error)
+
+    const payloads: SyncPayload[] = []
+    for (const file of result.value.files ?? []) {
+      if (!file.path.endsWith(FILE_EXTENSION)) continue
+      try {
+        const snapshot = JSON.parse(file.content) as ConversationSnapshot
+        payloads.push({
+          syncId: `sftp:${snapshot.id}`,
+          conversation: {
+            ...snapshot.conversation,
+            syncId: `sftp:${snapshot.id}`,
+            syncVersion: snapshot.syncVersion,
+          },
+          messages: snapshot.messages,
+          syncVersion: snapshot.syncVersion,
+          deviceId: snapshot.deviceId ?? this._deviceIdService.getOrCreate(),
+        })
+      } catch {
+        // Malformed remote file — skip, don't abort entire pull
+      }
+    }
+    return ok(payloads)
+  }
+
+  async testConnection(): Promise<Result<void, SyncError>> {
+    return this._send<void>('sync:sftp:test', {})
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private async _send<T>(
+    type: SftpRequest['type'],
+    payload: Record<string, unknown>
+  ): Promise<Result<T, SyncError>> {
+    const requestId = crypto.randomUUID()
+    const request = { type, requestId, ...payload } as SftpRequest
+
+    const result = await this._bridge.postAndAwait(
+      request as Parameters<typeof this._bridge.postAndAwait>[0],
+      (cb, ms) => setTimeout(cb, ms) as unknown as NodeJS.Timeout,
+      (id) => clearTimeout(id as unknown as ReturnType<typeof setTimeout>)
+    )
+
+    if (result.isErr()) {
+      const msg = result.error.message
+      if (msg.includes('auth') || msg.includes('Authentication')) {
+        return err(new SyncAuthError('sftp', msg))
+      }
+      return err(new SyncError('sftp', msg, result.error))
+    }
+
+    return ok(result.value as T)
+  }
+
+  private _remoteDir(): string {
+    return `${this._config.remotePath.replace(/\/$/, '')}/${FILE_PREFIX}`
+  }
+
+  private _filePath(conversationId: number): string {
+    return `${this._remoteDir()}${conversationId}${FILE_EXTENSION}`
+  }
+}

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -1,4 +1,4 @@
-import { ok, err, type Result } from 'neverthrow'
+import { ok, err, type Result, ResultAsync } from 'neverthrow'
 import { v4 as uuidv4 } from 'uuid'
 import type { AppDb } from '@/database/app-db'
 import type { Conversation, Message } from '@/database/types'
@@ -115,23 +115,12 @@ export class SyncManager {
   private async _pushOne(conversationId: number): Promise<void> {
     if (!this._adapter) return
 
-    const payloadResult = await this._buildPayload(conversationId)
-    if (payloadResult.isErr()) {
-      this._logger.error('SyncManager: failed to build payload', {
-        conversationId,
-        error: payloadResult.error,
+    await this._buildPayload(conversationId)
+      .andThen((payload) => ResultAsync.fromPromise(this._adapter!.push(payload), (e) => e as AppSyncError))
+      .mapErr((error) => {
+        this._logger.error('SyncManager: push failed', { conversationId, error })
+        this._emit({ state: 'error', error })
       })
-      return
-    }
-
-    const pushResult = await this._adapter.push(payloadResult.value)
-    if (pushResult.isErr()) {
-      this._logger.error('SyncManager: push failed', {
-        conversationId,
-        error: pushResult.error,
-      })
-      this._emit({ state: 'error', error: pushResult.error })
-    }
   }
 
   private async _pushTombstone(conversationId: number, syncVersion: number): Promise<void> {
@@ -197,19 +186,26 @@ export class SyncManager {
 
         if (resolution === 'use-local') {
           // Local is newer — push it and discard the remote payload
-          void this._adapter?.push(localPayload)
+          void this._adapter?.push(localPayload).then((result) => {
+            if (result && result.isErr()) {
+              this.notifyChanged(payload.conversation.id)
+            }
+          })
           return
         }
 
-        // resolution === 'use-remote': fall through to apply below,
-        // but also surface the conflict to handlers so the UI can notify the user.
-        const info: ConflictInfo = {
-          conversationId: payload.conversation.id,
-          localPayload,
-          remotePayload: payload,
+        // resolution === 'use-remote': fall through to apply below.
+        // Only emit conflict if versions are equal (the ambiguous case).
+        // If remote version is higher, it's just a normal background pull.
+        if (localPayload.syncVersion === payload.conversation.syncVersion) {
+          const info: ConflictInfo = {
+            conversationId: payload.conversation.id,
+            localPayload,
+            remotePayload: payload,
+          }
+          this._conflictHandlers.forEach((h) => h(info))
+          this._emit({ state: 'conflict', info })
         }
-        this._conflictHandlers.forEach((h) => h(info))
-        this._emit({ state: 'conflict', info })
         // Still apply the remote payload — it won the resolution
       }
     }

--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -5,6 +5,7 @@ import type { Conversation, Message } from '@/database/types'
 import { SyncError as AppSyncError } from '@/errors'
 import type { ISyncAdapter, SyncPayload, SyncStatus, ConflictInfo } from '@/sync/types'
 import type { AbstractLogger } from '@/logger'
+import { resolveConflict, shouldApplyRemote } from '@/sync/conflict-resolver'
 
 type StatusHandler = (status: SyncStatus) => void
 type ConflictHandler = (info: ConflictInfo) => void
@@ -92,7 +93,7 @@ export class SyncManager {
     this._emit({ state: 'success', lastSyncAt: new Date() })
   }
 
-  async resolveConflict(
+  async resolveConflictManual(
     info: ConflictInfo,
     resolution: 'local-wins' | 'remote-wins'
   ): Promise<void> {
@@ -184,25 +185,37 @@ export class SyncManager {
     if (localResult.isErr()) return
     const local = localResult.value
 
+    // If this conversation has unsaved local changes in the pending queue,
+    // run conflict resolution before deciding what to apply.
     if (local && this._pending.has(payload.conversation.id)) {
       const localPayloadResult = await this._buildPayload(payload.conversation.id)
       if (localPayloadResult.isOk()) {
+        const localPayload = localPayloadResult.value
+        const resolution = resolveConflict(localPayload, payload)
+
+        if (resolution === 'noop') return
+
+        if (resolution === 'use-local') {
+          // Local is newer — push it and discard the remote payload
+          void this._adapter?.push(localPayload)
+          return
+        }
+
+        // resolution === 'use-remote': fall through to apply below,
+        // but also surface the conflict to handlers so the UI can notify the user.
         const info: ConflictInfo = {
           conversationId: payload.conversation.id,
-          localPayload: localPayloadResult.value,
+          localPayload,
           remotePayload: payload,
         }
-        this._conflictHandlers.forEach((h) => {
-          h(info)
-        })
+        this._conflictHandlers.forEach((h) => h(info))
         this._emit({ state: 'conflict', info })
-        return
+        // Still apply the remote payload — it won the resolution
       }
     }
 
-    if (local?.syncVersion !== undefined && payload.syncVersion <= local.syncVersion) {
-      return
-    }
+    // Skip if local is already at this version or newer
+    if (!shouldApplyRemote(local?.syncVersion, payload)) return
 
     const conv: Conversation = {
       id: payload.conversation.id,

--- a/src/sync/sync-queue.ts
+++ b/src/sync/sync-queue.ts
@@ -3,6 +3,8 @@ import { defineStore } from 'pinia'
 import type { SyncStatus, SyncBackend, ConflictInfo } from '@/sync/types'
 import { SyncManager } from '@/sync/sync-manager'
 import { GitHubSyncAdapter } from '@/sync/github-adapter'
+import { WebDavSyncAdapter } from '@/sync/webdav-adapter'
+import { SftpBridgeAdapter } from '@/sync/sftp-bridge-adapter'
 import { DeviceIdService } from '@/sync/device-id'
 import { safeInject } from '@/safe-inject'
 import { APP_DB_KEY, LOGGER_KEY } from '@/injection-keys'
@@ -58,6 +60,53 @@ export const useSyncStore = defineStore('sync', () => {
       )
       manager.setAdapter(adapter)
       activeBackend.value = 'github'
+
+      const testResult = await adapter.testConnection()
+      if (testResult.isErr()) {
+        status.value = { state: 'error', error: testResult.error }
+        return
+      }
+
+      void manager.pullAll()
+      return
+    }
+
+    if (config.backend === 'webdav') {
+      const adapter = new WebDavSyncAdapter(
+        {
+          url: config.url,
+          username: config.username,
+          password: config.password,
+        },
+        deviceIdService,
+        db
+      )
+      manager.setAdapter(adapter)
+      activeBackend.value = 'webdav'
+
+      const testResult = await adapter.testConnection()
+      if (testResult.isErr()) {
+        status.value = { state: 'error', error: testResult.error }
+        return
+      }
+
+      void manager.pullAll()
+      return
+    }
+
+    if (config.backend === 'sftp') {
+      const adapter = new SftpBridgeAdapter(
+        {
+          host: config.host,
+          port: config.port,
+          username: config.username,
+          privateKeyOrPassword: config.privateKey,
+          remotePath: '', // TODO: allow config?
+        },
+        deviceIdService
+      )
+      manager.setAdapter(adapter)
+      activeBackend.value = 'sftp'
 
       const testResult = await adapter.testConnection()
       if (testResult.isErr()) {

--- a/src/sync/webdav-adapter.ts
+++ b/src/sync/webdav-adapter.ts
@@ -1,0 +1,250 @@
+import { ok, err, type Result } from 'neverthrow'
+import { SyncError, SyncAuthError, ConflictError } from '@/errors'
+import type { ISyncAdapter, SyncPayload, ConversationSnapshot, ConversationSnapshotForUpload } from '@/sync/types'
+import type { DeviceIdService } from '@/sync/device-id'
+
+const FILE_PREFIX = 'chats/'
+const FILE_EXTENSION = '.json'
+
+export type WebDavAdapterConfig = {
+  url: string
+  username: string
+  password: string
+}
+
+export class WebDavSyncAdapter implements ISyncAdapter {
+  readonly name = 'webdav'
+
+  constructor(
+    private readonly _config: WebDavAdapterConfig,
+    private readonly _deviceIdService: DeviceIdService
+  ) {}
+
+  async push(payload: SyncPayload): Promise<Result<void, SyncError>> {
+    if (payload.deletedAt) {
+      return this._remove(payload.conversation.id)
+    }
+    const snapshot: ConversationSnapshotForUpload = {
+      id: payload.conversation.id,
+      syncVersion: payload.syncVersion,
+      conversation: payload.conversation,
+      messages: payload.messages,
+      deviceId: payload.deviceId,
+    }
+    return this._upload(snapshot)
+  }
+
+  async pull(): Promise<Result<SyncPayload[], SyncError>> {
+    const listResult = await this._listRemote()
+    if (listResult.isErr()) return err(listResult.error)
+
+    const payloads: SyncPayload[] = []
+
+    for (const { id } of listResult.value) {
+      const downloadResult = await this._download(id)
+      if (downloadResult.isErr()) return err(downloadResult.error)
+      const snapshot = downloadResult.value
+      if (!snapshot) continue
+
+      const payload: SyncPayload = {
+        syncId: `webdav:${id}`,
+        conversation: {
+          ...snapshot.conversation,
+          syncId: `webdav:${id}`,
+          syncVersion: snapshot.syncVersion,
+        },
+        messages: snapshot.messages,
+        syncVersion: snapshot.syncVersion,
+        deviceId: snapshot.deviceId ?? this._deviceIdService.getOrCreate(),
+      }
+      payloads.push(payload)
+    }
+
+    return ok(payloads)
+  }
+
+  async testConnection(): Promise<Result<void, SyncError>> {
+    const result = await this._request('HEAD', this._baseDir())
+    if (result.isErr()) return err(result.error)
+    return ok(undefined)
+  }
+
+  // ─── Private ────────────────────────────────────────────────────────────────
+
+  private async _upload(snapshot: ConversationSnapshotForUpload): Promise<Result<void, SyncError>> {
+    const url = this._fileUrl(snapshot.id)
+    const body = JSON.stringify({ ...snapshot, deviceId: snapshot.deviceId ?? this._deviceIdService.getOrCreate() }, null, 2)
+
+    // Fetch current ETag for optimistic locking
+    const etagResult = await this._getEtag(url)
+    const etag = etagResult.isOk() ? etagResult.value : null
+
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+      ...this._authHeader(),
+    }
+    if (etag) {
+      // If-Match ensures we don't overwrite a newer remote version
+      ;(headers as Record<string, string>)['If-Match'] = etag
+    }
+
+    try {
+      const res = await fetch(url, { method: 'PUT', headers, body })
+
+      if (res.status === 401 || res.status === 403) {
+        return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
+      }
+
+      if (res.status === 412) {
+        // Precondition Failed — remote has diverged; surface as ConflictError
+        return err(
+          new ConflictError('webdav', snapshot.id, snapshot.syncVersion, -1)
+        )
+      }
+
+      if (!res.ok) {
+        return err(new SyncError('webdav', `PUT failed: HTTP ${res.status}`))
+      }
+
+      return ok(undefined)
+    } catch (e) {
+      return err(new SyncError('webdav', `Network error during PUT: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  private async _download(conversationId: number): Promise<Result<ConversationSnapshot | null, SyncError>> {
+    const url = this._fileUrl(conversationId)
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: { ...this._authHeader(), Accept: 'application/json' },
+      })
+
+      if (res.status === 404) return ok(null)
+      if (res.status === 401 || res.status === 403) {
+        return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
+      }
+      if (!res.ok) {
+        return err(new SyncError('webdav', `GET failed: HTTP ${res.status}`))
+      }
+
+      try {
+        const snapshot = (await res.json()) as ConversationSnapshot
+        return ok(snapshot)
+      } catch (e) {
+        return err(new SyncError('webdav', `Failed to parse remote snapshot for conversation ${conversationId}`, e))
+      }
+    } catch (e) {
+      return err(new SyncError('webdav', `Network error during GET: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  private async _remove(conversationId: number): Promise<Result<void, SyncError>> {
+    const url = this._fileUrl(conversationId)
+    try {
+      const res = await fetch(url, {
+        method: 'DELETE',
+        headers: this._authHeader(),
+      })
+
+      if (res.status === 404) return ok(undefined)
+      if (res.status === 401 || res.status === 403) {
+        return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
+      }
+      if (!res.ok) {
+        return err(new SyncError('webdav', `DELETE failed: HTTP ${res.status}`))
+      }
+      return ok(undefined)
+    } catch (e) {
+      return err(new SyncError('webdav', `Network error during DELETE: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  private async _listRemote(): Promise<Result<Array<{ id: number }>, SyncError>> {
+    // PROPFIND depth 1 to list files in the chats/ directory
+    const body = `<?xml version="1.0" encoding="utf-8"?>
+<D:propfind xmlns:D="DAV:">
+  <D:prop><D:displayname/></D:prop>
+</D:propfind>`
+
+    try {
+      const res = await fetch(this._baseDir(), {
+        method: 'PROPFIND',
+        headers: {
+          ...this._authHeader(),
+          Depth: '1',
+          'Content-Type': 'application/xml',
+        },
+        body,
+      })
+
+      if (res.status === 404) return ok([])
+      if (res.status === 401 || res.status === 403) {
+        return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
+      }
+      if (!res.ok && res.status !== 207) {
+        return err(new SyncError('webdav', `PROPFIND failed: HTTP ${res.status}`))
+      }
+
+      const xml = await res.text()
+      const ids = this._parseMultistatus(xml)
+      return ok(ids.map((id) => ({ id })))
+    } catch (e) {
+      return err(new SyncError('webdav', `Network error during PROPFIND: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  private async _getEtag(url: string): Promise<Result<string, SyncError>> {
+    try {
+      const res = await fetch(url, { method: 'HEAD', headers: this._authHeader() })
+      if (!res.ok) return err(new SyncError('webdav', `HEAD failed: HTTP ${res.status}`))
+      const etag = res.headers.get('ETag')
+      if (!etag) return err(new SyncError('webdav', 'No ETag in HEAD response'))
+      return ok(etag)
+    } catch (e) {
+      return err(new SyncError('webdav', `HEAD error: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  private async _request(method: string, url: string): Promise<Result<void, SyncError>> {
+    try {
+      const res = await fetch(url, { method, headers: this._authHeader() })
+      if (res.status === 401 || res.status === 403) {
+        return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
+      }
+      if (!res.ok) return err(new SyncError('webdav', `${method} failed: HTTP ${res.status}`))
+      return ok(undefined)
+    } catch (e) {
+      return err(new SyncError('webdav', `Network error: ${e instanceof Error ? e.message : String(e)}`, e))
+    }
+  }
+
+  /** Parse a WebDAV 207 Multi-Status XML body and return conversation IDs */
+  private _parseMultistatus(xml: string): number[] {
+    const ids: number[] = []
+    // Simple regex-based parse — avoids DOM parser dependency issues in webview context
+    const hrefPattern = /<[Dd]:[Hh]ref>([^<]+)<\/[Dd]:[Hh]ref>/g
+    let match: RegExpExecArray | null
+    while ((match = hrefPattern.exec(xml)) !== null) {
+      const href = decodeURIComponent(match[1].trim())
+      const filename = href.split('/').pop() ?? ''
+      if (!filename.endsWith(FILE_EXTENSION)) continue
+      const id = parseInt(filename.replace(FILE_EXTENSION, ''), 10)
+      if (!isNaN(id)) ids.push(id)
+    }
+    return ids
+  }
+
+  private _authHeader(): Record<string, string> {
+    const credentials = btoa(`${this._config.username}:${this._config.password}`)
+    return { Authorization: `Basic ${credentials}` }
+  }
+
+  private _baseDir(): string {
+    return `${this._config.url.replace(/\/$/, '')}/${FILE_PREFIX}`
+  }
+
+  private _fileUrl(conversationId: number): string {
+    return `${this._baseDir()}${conversationId}${FILE_EXTENSION}`
+  }
+}

--- a/src/sync/webdav-adapter.ts
+++ b/src/sync/webdav-adapter.ts
@@ -1,4 +1,4 @@
-import { ok, err, type Result } from 'neverthrow'
+import { ok, err, type Result, ResultAsync } from 'neverthrow'
 import { SyncError, SyncAuthError, ConflictError } from '@/errors'
 import type { ISyncAdapter, SyncPayload, ConversationSnapshot, ConversationSnapshotForUpload } from '@/sync/types'
 import type { DeviceIdService } from '@/sync/device-id'
@@ -12,12 +12,22 @@ export type WebDavAdapterConfig = {
   password: string
 }
 
+import type { AppDb } from '@/database/app-db'
+
+/**
+ * WebDAV Sync Adapter.
+ *
+ * Implements conversation synchronization over WebDAV.
+ * Uses PROPFIND optimization to skip downloading unchanged files.
+ * Provides optimistic locking via ETags and If-Match/If-None-Match headers.
+ */
 export class WebDavSyncAdapter implements ISyncAdapter {
   readonly name = 'webdav'
 
   constructor(
     private readonly _config: WebDavAdapterConfig,
-    private readonly _deviceIdService: DeviceIdService
+    private readonly _deviceIdService: DeviceIdService,
+    private readonly _db: AppDb
   ) {}
 
   async push(payload: SyncPayload): Promise<Result<void, SyncError>> {
@@ -34,13 +44,27 @@ export class WebDavSyncAdapter implements ISyncAdapter {
     return this._upload(snapshot)
   }
 
+  /**
+   * Pulls all conversations from the remote WebDAV server.
+   * Optimized to only fetch files that have a newer modification date than local.
+   */
   async pull(): Promise<Result<SyncPayload[], SyncError>> {
     const listResult = await this._listRemote()
     if (listResult.isErr()) return err(listResult.error)
 
     const payloads: SyncPayload[] = []
 
-    for (const { id } of listResult.value) {
+    for (const { id, lastModified } of listResult.value) {
+      // PROPFIND optimization: Check if we actually need to download this file.
+      // If we have a local version and it's newer or equal to the remote mod date, skip download.
+      // This solves the N+1 requests problem by only fetching changed files.
+      if (lastModified) {
+        const localResult = await this._db.conversation.get(id)
+        if (localResult.isOk() && localResult.value && localResult.value.updatedAt >= lastModified) {
+          continue
+        }
+      }
+
       const downloadResult = await this._download(id)
       if (downloadResult.isErr()) return err(downloadResult.error)
       const snapshot = downloadResult.value
@@ -73,53 +97,58 @@ export class WebDavSyncAdapter implements ISyncAdapter {
 
   private async _upload(snapshot: ConversationSnapshotForUpload): Promise<Result<void, SyncError>> {
     const url = this._fileUrl(snapshot.id)
-    const body = JSON.stringify({ ...snapshot, deviceId: snapshot.deviceId ?? this._deviceIdService.getOrCreate() }, null, 2)
+    const body = JSON.stringify(
+      { ...snapshot, deviceId: snapshot.deviceId ?? this._deviceIdService.getOrCreate() },
+      null,
+      2
+    )
 
     // Fetch current ETag for optimistic locking
     const etagResult = await this._getEtag(url)
     const etag = etagResult.isOk() ? etagResult.value : null
 
-    const headers: HeadersInit = {
+    const headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...this._authHeader(),
     }
     if (etag) {
-      // If-Match ensures we don't overwrite a newer remote version
-      ;(headers as Record<string, string>)['If-Match'] = etag
+      headers['If-Match'] = etag
+    } else {
+      headers['If-None-Match'] = '*'
     }
 
-    try {
-      const res = await fetch(url, { method: 'PUT', headers, body })
-
+    return ResultAsync.fromPromise(fetch(url, { method: 'PUT', headers, body }), (e) =>
+      new SyncError('webdav', `Network error during PUT: ${e instanceof Error ? e.message : String(e)}`, e)
+    ).andThen(async (res) => {
       if (res.status === 401 || res.status === 403) {
         return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
       }
-
       if (res.status === 412) {
-        // Precondition Failed — remote has diverged; surface as ConflictError
-        return err(
-          new ConflictError('webdav', snapshot.id, snapshot.syncVersion, -1)
-        )
+        return err(new ConflictError('webdav', snapshot.id, snapshot.syncVersion))
       }
-
       if (!res.ok) {
         return err(new SyncError('webdav', `PUT failed: HTTP ${res.status}`))
       }
-
       return ok(undefined)
-    } catch (e) {
-      return err(new SyncError('webdav', `Network error during PUT: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+    })
   }
 
-  private async _download(conversationId: number): Promise<Result<ConversationSnapshot | null, SyncError>> {
+  private async _download(
+    conversationId: number
+  ): Promise<Result<ConversationSnapshot | null, SyncError>> {
     const url = this._fileUrl(conversationId)
-    try {
-      const res = await fetch(url, {
+    return ResultAsync.fromPromise(
+      fetch(url, {
         method: 'GET',
         headers: { ...this._authHeader(), Accept: 'application/json' },
-      })
-
+      }),
+      (e) =>
+        new SyncError(
+          'webdav',
+          `Network error during GET: ${e instanceof Error ? e.message : String(e)}`,
+          e
+        )
+    ).andThen(async (res) => {
       if (res.status === 404) return ok(null)
       if (res.status === 401 || res.status === 403) {
         return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
@@ -128,25 +157,30 @@ export class WebDavSyncAdapter implements ISyncAdapter {
         return err(new SyncError('webdav', `GET failed: HTTP ${res.status}`))
       }
 
-      try {
-        const snapshot = (await res.json()) as ConversationSnapshot
-        return ok(snapshot)
-      } catch (e) {
-        return err(new SyncError('webdav', `Failed to parse remote snapshot for conversation ${conversationId}`, e))
-      }
-    } catch (e) {
-      return err(new SyncError('webdav', `Network error during GET: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+      return ResultAsync.fromPromise(res.json() as Promise<ConversationSnapshot>, (e) =>
+        new SyncError(
+          'webdav',
+          `Failed to parse remote snapshot for conversation ${conversationId}`,
+          e
+        )
+      )
+    })
   }
 
   private async _remove(conversationId: number): Promise<Result<void, SyncError>> {
     const url = this._fileUrl(conversationId)
-    try {
-      const res = await fetch(url, {
+    return ResultAsync.fromPromise(
+      fetch(url, {
         method: 'DELETE',
         headers: this._authHeader(),
-      })
-
+      }),
+      (e) =>
+        new SyncError(
+          'webdav',
+          `Network error during DELETE: ${e instanceof Error ? e.message : String(e)}`,
+          e
+        )
+    ).andThen(async (res) => {
       if (res.status === 404) return ok(undefined)
       if (res.status === 401 || res.status === 403) {
         return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
@@ -155,20 +189,22 @@ export class WebDavSyncAdapter implements ISyncAdapter {
         return err(new SyncError('webdav', `DELETE failed: HTTP ${res.status}`))
       }
       return ok(undefined)
-    } catch (e) {
-      return err(new SyncError('webdav', `Network error during DELETE: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+    })
   }
 
-  private async _listRemote(): Promise<Result<Array<{ id: number }>, SyncError>> {
-    // PROPFIND depth 1 to list files in the chats/ directory
+  private async _listRemote(): Promise<
+    Result<Array<{ id: number; lastModified?: Date }>, SyncError>
+  > {
     const body = `<?xml version="1.0" encoding="utf-8"?>
 <D:propfind xmlns:D="DAV:">
-  <D:prop><D:displayname/></D:prop>
+  <D:prop>
+    <D:displayname/>
+    <D:getlastmodified/>
+  </D:prop>
 </D:propfind>`
 
-    try {
-      const res = await fetch(this._baseDir(), {
+    return ResultAsync.fromPromise(
+      fetch(this._baseDir(), {
         method: 'PROPFIND',
         headers: {
           ...this._authHeader(),
@@ -176,8 +212,14 @@ export class WebDavSyncAdapter implements ISyncAdapter {
           'Content-Type': 'application/xml',
         },
         body,
-      })
-
+      }),
+      (e) =>
+        new SyncError(
+          'webdav',
+          `Network error during PROPFIND: ${e instanceof Error ? e.message : String(e)}`,
+          e
+        )
+    ).andThen(async (res) => {
       if (res.status === 404) return ok([])
       if (res.status === 401 || res.status === 403) {
         return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
@@ -187,52 +229,62 @@ export class WebDavSyncAdapter implements ISyncAdapter {
       }
 
       const xml = await res.text()
-      const ids = this._parseMultistatus(xml)
-      return ok(ids.map((id) => ({ id })))
-    } catch (e) {
-      return err(new SyncError('webdav', `Network error during PROPFIND: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+      return ok(this._parseMultistatus(xml))
+    })
   }
 
-  private async _getEtag(url: string): Promise<Result<string, SyncError>> {
-    try {
-      const res = await fetch(url, { method: 'HEAD', headers: this._authHeader() })
+  private _getEtag(url: string): ResultAsync<string, SyncError> {
+    return ResultAsync.fromPromise(fetch(url, { method: 'HEAD', headers: this._authHeader() }), (e) =>
+      new SyncError('webdav', `HEAD error: ${e instanceof Error ? e.message : String(e)}`, e)
+    ).andThen((res) => {
       if (!res.ok) return err(new SyncError('webdav', `HEAD failed: HTTP ${res.status}`))
       const etag = res.headers.get('ETag')
       if (!etag) return err(new SyncError('webdav', 'No ETag in HEAD response'))
       return ok(etag)
-    } catch (e) {
-      return err(new SyncError('webdav', `HEAD error: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+    })
   }
 
   private async _request(method: string, url: string): Promise<Result<void, SyncError>> {
-    try {
-      const res = await fetch(url, { method, headers: this._authHeader() })
+    return ResultAsync.fromPromise(fetch(url, { method, headers: this._authHeader() }), (e) =>
+      new SyncError('webdav', `Network error: ${e instanceof Error ? e.message : String(e)}`, e)
+    ).andThen(async (res) => {
       if (res.status === 401 || res.status === 403) {
         return err(new SyncAuthError('webdav', `HTTP ${res.status}`))
       }
       if (!res.ok) return err(new SyncError('webdav', `${method} failed: HTTP ${res.status}`))
       return ok(undefined)
-    } catch (e) {
-      return err(new SyncError('webdav', `Network error: ${e instanceof Error ? e.message : String(e)}`, e))
-    }
+    })
   }
 
-  /** Parse a WebDAV 207 Multi-Status XML body and return conversation IDs */
-  private _parseMultistatus(xml: string): number[] {
-    const ids: number[] = []
-    // Simple regex-based parse — avoids DOM parser dependency issues in webview context
-    const hrefPattern = /<[Dd]:[Hh]ref>([^<]+)<\/[Dd]:[Hh]ref>/g
-    let match: RegExpExecArray | null
-    while ((match = hrefPattern.exec(xml)) !== null) {
-      const href = decodeURIComponent(match[1].trim())
+  /** Parse a WebDAV 207 Multi-Status XML body and return conversation IDs and mod dates */
+  private _parseMultistatus(xml: string): Array<{ id: number; lastModified?: Date }> {
+    const results: Array<{ id: number; lastModified?: Date }> = []
+
+    // Each file is in a <D:response> block. Extract them.
+    const responsePattern = /<[Dd]:[Rr]esponse>([\s\S]*?)<\/[Dd]:[Rr]esponse>/g
+    const hrefPattern = /<[Dd]:[Hh]ref>([^<]+)<\/[Dd]:[Hh]ref>/
+    const datePattern = /<[Dd]:[Gg]etlastmodified>([^<]+)<\/[Dd]:[Gg]etlastmodified>/
+
+    let responseMatch: RegExpExecArray | null
+    while ((responseMatch = responsePattern.exec(xml)) !== null) {
+      const block = responseMatch[1]
+
+      const hrefMatch = hrefPattern.exec(block)
+      if (!hrefMatch) continue
+
+      const href = decodeURIComponent(hrefMatch[1].trim())
       const filename = href.split('/').pop() ?? ''
       if (!filename.endsWith(FILE_EXTENSION)) continue
+
       const id = parseInt(filename.replace(FILE_EXTENSION, ''), 10)
-      if (!isNaN(id)) ids.push(id)
+      if (isNaN(id)) continue
+
+      const dateMatch = datePattern.exec(block)
+      const lastModified = dateMatch ? new Date(dateMatch[1]) : undefined
+
+      results.push({ id, lastModified: lastModified && !isNaN(lastModified.getTime()) ? lastModified : undefined })
     }
-    return ids
+    return results
   }
 
   private _authHeader(): Record<string, string> {

--- a/src/vs-code/sftp-host-service.ts
+++ b/src/vs-code/sftp-host-service.ts
@@ -56,6 +56,7 @@ function isSftpMessage(msg: unknown): msg is SftpMessage {
 
 export class SftpHostService {
   private _disposable: { dispose(): void } | null = null
+  private _client: any | null = null
 
   constructor(
     private readonly _panel: WebviewPanel,
@@ -69,50 +70,84 @@ export class SftpHostService {
     })
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     this._disposable?.dispose()
     this._disposable = null
+    if (this._client) {
+      try {
+        await this._client.end()
+      } catch {
+        // Ignore close errors
+      }
+      this._client = null
+    }
+  }
+
+  private async _getClient(): Promise<any> {
+    if (this._client) return this._client
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const SftpClient = (await import('ssh2-sftp-client')).default
+    this._client = new SftpClient()
+
+    // Add error listener to reset client on connection loss
+    this._client.on('error', () => {
+      this._client = null
+    })
+    this._client.on('close', () => {
+      this._client = null
+    })
+
+    await this._client.connect(this._connectConfig())
+    return this._client
+  }
+
+  private async _ensureConnection(): Promise<any> {
+    try {
+      const client = await this._getClient()
+      return client
+    } catch (e) {
+      this._client = null
+      throw e
+    }
   }
 
   private async _handle(msg: SftpMessage): Promise<void> {
-    switch (msg.type) {
-      case 'sync:sftp:test':
-        await this._handleTest(msg)
-        break
-      case 'sync:sftp:push':
-        await this._handlePush(msg)
-        break
-      case 'sync:sftp:pull':
-        await this._handlePull(msg)
-        break
-      case 'sync:sftp:delete':
-        await this._handleDelete(msg)
-        break
+    try {
+      switch (msg.type) {
+        case 'sync:sftp:test':
+          await this._handleTest(msg)
+          break
+        case 'sync:sftp:push':
+          await this._handlePush(msg)
+          break
+        case 'sync:sftp:pull':
+          await this._handlePull(msg)
+          break
+        case 'sync:sftp:delete':
+          await this._handleDelete(msg)
+          break
+      }
+    } catch (e) {
+      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
     }
   }
 
   private async _handleTest(msg: SftpMessage): Promise<void> {
-    // Dynamic import — ssh2-sftp-client is Node-only, never bundled into webview
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const SftpClient = (await import('ssh2-sftp-client')).default
-    const client = new SftpClient()
     try {
-      await client.connect(this._connectConfig())
-      await client.end()
-      this._reply(msg.requestId, {})
+      const client = await this._ensureConnection()
+      // Connection test passed if we got here
+      this._reply(msg.requestId, { type: 'sync:sftp:response' })
     } catch (e) {
-      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+      this._reply(msg.requestId, { type: 'sync:sftp:response', error: e instanceof Error ? e.message : String(e) })
     }
   }
 
   private async _handlePush(msg: SftpMessage): Promise<void> {
     const path = msg.path as string
     const content = msg.content as string
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const SftpClient = (await import('ssh2-sftp-client')).default
-    const client = new SftpClient()
     try {
-      await client.connect(this._connectConfig())
+      const client = await this._ensureConnection()
       // Ensure parent directory exists
       const dir = path.substring(0, path.lastIndexOf('/'))
       await client.mkdir(dir, true)
@@ -121,20 +156,16 @@ export class SftpHostService {
       const buffer = Buffer.from(content, 'utf-8')
       await client.put(buffer, tmpPath)
       await client.rename(tmpPath, path)
-      await client.end()
-      this._reply(msg.requestId, {})
+      this._reply(msg.requestId, { type: 'sync:sftp:response' })
     } catch (e) {
-      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+      this._reply(msg.requestId, { type: 'sync:sftp:response', error: e instanceof Error ? e.message : String(e) })
     }
   }
 
   private async _handlePull(msg: SftpMessage): Promise<void> {
     const dirPath = msg.dirPath as string
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const SftpClient = (await import('ssh2-sftp-client')).default
-    const client = new SftpClient()
     try {
-      await client.connect(this._connectConfig())
+      const client = await this._ensureConnection()
 
       // List files in directory; if dir doesn't exist yet return empty
       let listing: Array<{ name: string }> = []
@@ -156,29 +187,24 @@ export class SftpHostService {
         }
       }
 
-      await client.end()
-      this._reply(msg.requestId, { files })
+      this._reply(msg.requestId, { type: 'sync:sftp:response', files })
     } catch (e) {
-      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+      this._reply(msg.requestId, { type: 'sync:sftp:response', error: e instanceof Error ? e.message : String(e) })
     }
   }
 
   private async _handleDelete(msg: SftpMessage): Promise<void> {
     const path = msg.path as string
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const SftpClient = (await import('ssh2-sftp-client')).default
-    const client = new SftpClient()
     try {
-      await client.connect(this._connectConfig())
+      const client = await this._ensureConnection()
       try {
         await client.delete(path)
       } catch {
         // File already gone — treat as success
       }
-      await client.end()
-      this._reply(msg.requestId, {})
+      this._reply(msg.requestId, { type: 'sync:sftp:response' })
     } catch (e) {
-      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+      this._reply(msg.requestId, { type: 'sync:sftp:response', error: e instanceof Error ? e.message : String(e) })
     }
   }
 

--- a/src/vs-code/sftp-host-service.ts
+++ b/src/vs-code/sftp-host-service.ts
@@ -1,0 +1,203 @@
+/**
+ * VS Code Extension Host — SFTP host service.
+ *
+ * This module runs in the extension host (Node.js), NOT in the webview.
+ * It receives sync:sftp:* messages from SftpBridgeAdapter via the webview
+ * postMessage bridge and performs actual SFTP I/O using ssh2-sftp-client.
+ *
+ * Usage in your extension's activate():
+ *
+ *   import { SftpHostService } from './sftp-host-service'
+ *
+ *   const sftp = new SftpHostService(panel.webview, {
+ *     host: '…', port: 22, username: '…', privateKey: await getKeyFromSecretStorage(),
+ *   })
+ *   sftp.listen()
+ *
+ * The webview panel's onDidReceiveMessage is wired through SftpHostService.listen().
+ * Credentials are fetched from VS Code SecretStorage — never hardcoded or stored in app-db.
+ */
+
+// NOTE: The import below is a dynamic import to keep this file tree-shakeable.
+// ssh2-sftp-client is a Node-only package and must never be bundled into the webview.
+// Import it only at the extension host boundary.
+
+export type SftpHostConfig = {
+  host: string
+  port: number
+  username: string
+  /** Private key (PEM string) or password — sourced from SecretStorage by the caller */
+  authValue: string
+  authType: 'privateKey' | 'password'
+}
+
+export type WebviewPanel = {
+  webview: {
+    postMessage(message: unknown): void
+    onDidReceiveMessage: (listener: (message: unknown) => void) => { dispose(): void }
+  }
+}
+
+type SftpMessage = {
+  type: string
+  requestId: string
+  [key: string]: unknown
+}
+
+function isSftpMessage(msg: unknown): msg is SftpMessage {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    typeof (msg as Record<string, unknown>).type === 'string' &&
+    typeof (msg as Record<string, unknown>).requestId === 'string' &&
+    ((msg as Record<string, unknown>).type as string).startsWith('sync:sftp:')
+  )
+}
+
+export class SftpHostService {
+  private _disposable: { dispose(): void } | null = null
+
+  constructor(
+    private readonly _panel: WebviewPanel,
+    private readonly _config: SftpHostConfig
+  ) {}
+
+  listen(): void {
+    this._disposable = this._panel.webview.onDidReceiveMessage(async (msg: unknown) => {
+      if (!isSftpMessage(msg)) return
+      await this._handle(msg)
+    })
+  }
+
+  dispose(): void {
+    this._disposable?.dispose()
+    this._disposable = null
+  }
+
+  private async _handle(msg: SftpMessage): Promise<void> {
+    switch (msg.type) {
+      case 'sync:sftp:test':
+        await this._handleTest(msg)
+        break
+      case 'sync:sftp:push':
+        await this._handlePush(msg)
+        break
+      case 'sync:sftp:pull':
+        await this._handlePull(msg)
+        break
+      case 'sync:sftp:delete':
+        await this._handleDelete(msg)
+        break
+    }
+  }
+
+  private async _handleTest(msg: SftpMessage): Promise<void> {
+    // Dynamic import — ssh2-sftp-client is Node-only, never bundled into webview
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const SftpClient = (await import('ssh2-sftp-client')).default
+    const client = new SftpClient()
+    try {
+      await client.connect(this._connectConfig())
+      await client.end()
+      this._reply(msg.requestId, {})
+    } catch (e) {
+      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  private async _handlePush(msg: SftpMessage): Promise<void> {
+    const path = msg.path as string
+    const content = msg.content as string
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const SftpClient = (await import('ssh2-sftp-client')).default
+    const client = new SftpClient()
+    try {
+      await client.connect(this._connectConfig())
+      // Ensure parent directory exists
+      const dir = path.substring(0, path.lastIndexOf('/'))
+      await client.mkdir(dir, true)
+      // Write-then-rename for atomicity: write to .tmp, then rename
+      const tmpPath = `${path}.tmp`
+      const buffer = Buffer.from(content, 'utf-8')
+      await client.put(buffer, tmpPath)
+      await client.rename(tmpPath, path)
+      await client.end()
+      this._reply(msg.requestId, {})
+    } catch (e) {
+      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  private async _handlePull(msg: SftpMessage): Promise<void> {
+    const dirPath = msg.dirPath as string
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const SftpClient = (await import('ssh2-sftp-client')).default
+    const client = new SftpClient()
+    try {
+      await client.connect(this._connectConfig())
+
+      // List files in directory; if dir doesn't exist yet return empty
+      let listing: Array<{ name: string }> = []
+      try {
+        listing = (await client.list(dirPath)) as Array<{ name: string }>
+      } catch {
+        // Directory not yet created — treat as empty
+      }
+
+      const files: Array<{ path: string; content: string }> = []
+      for (const entry of listing) {
+        if (!entry.name.endsWith('.json')) continue
+        const filePath = `${dirPath}${entry.name}`
+        try {
+          const buffer = await client.get(filePath) as Buffer
+          files.push({ path: filePath, content: buffer.toString('utf-8') })
+        } catch {
+          // Skip unreadable files — don't abort entire pull
+        }
+      }
+
+      await client.end()
+      this._reply(msg.requestId, { files })
+    } catch (e) {
+      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  private async _handleDelete(msg: SftpMessage): Promise<void> {
+    const path = msg.path as string
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const SftpClient = (await import('ssh2-sftp-client')).default
+    const client = new SftpClient()
+    try {
+      await client.connect(this._connectConfig())
+      try {
+        await client.delete(path)
+      } catch {
+        // File already gone — treat as success
+      }
+      await client.end()
+      this._reply(msg.requestId, {})
+    } catch (e) {
+      this._reply(msg.requestId, { error: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  private _reply(requestId: string, payload: Record<string, unknown>): void {
+    this._panel.webview.postMessage({ requestId, ...payload })
+  }
+
+  private _connectConfig(): Record<string, unknown> {
+    const base: Record<string, unknown> = {
+      host: this._config.host,
+      port: this._config.port,
+      username: this._config.username,
+      readyTimeout: 10_000,
+    }
+    if (this._config.authType === 'privateKey') {
+      base.privateKey = this._config.authValue
+    } else {
+      base.password = this._config.authValue
+    }
+    return base
+  }
+}

--- a/src/vs-code/types.ts
+++ b/src/vs-code/types.ts
@@ -120,6 +120,13 @@ export type UnknownIncomingMessage = Readonly<{
   type: string
 }>
 
+export type SftpResponse = Readonly<{
+  type: 'sync:sftp:response'
+  requestId: string
+  error?: string
+  files?: Array<{ path: string; content: string }>
+}>
+
 export type IncomingMessage =
   | ContextSnapshotMessage
   | AutoContextResponse
@@ -128,6 +135,7 @@ export type IncomingMessage =
   | ContextPinSnippetMessage
   | AuthErrorIncomingMessage
   | AuthSessionIncomingMessage
+  | SftpResponse
   | UnknownIncomingMessage
 
 export type PinnedEntry = Readonly<{


### PR DESCRIPTION
## ❌ Closing — superseded by new spec

This PR is being closed because it diverges from the finalized sync spec (issue [#91](https://github.com/BabaDeluxe/babadeluxe-webview/issues/91)) in several ways that are now **permanently excluded**:

- Ships `sftp-bridge-adapter.ts` + `sftp-host-service.ts` — SFTP is permanently excluded from the sync design.
- Uses ETag + `If-Match` optimistic locking and surfaces `ConflictError` on HTTP 412 — the spec mandates **plain overwrites only, no conditional headers ever**.
- Ships `conflict-resolver.ts` — the spec is last-write-wins with **no conflict resolution layer**.

The correct implementation follows from issue #91. PR [#139](https://github.com/BabaDeluxe/babadeluxe-webview/pull/139) is the closest existing starting point but also needs to be audited against the spec before merging.