### PR TITLE
Documentation Regression Pass and Fixes

### DIFF
--- a/DOC_DRIFT.md
+++ b/DOC_DRIFT.md
@@ -66,3 +66,33 @@ This file documents discrepancies between the codebase implementation and the pr
 - Fixed `useSettings` composable to not hardcode `import.meta.env.MODE === 'test'` as offline mode, which was preventing socket-based integration tests from running their intended logic.
 - Expanded `mockDb` in `use-settings-socket.test.ts` to include `add`, `put`, `update`, and `delete` methods, resolving `TypeError` during test execution.
 - Updated `SettingsView` and `useSettings` mocks to return proper `neverthrow` `Result` types and reactive refs, resolving "Cannot read properties of undefined (reading 'value')" errors.
+
+---
+
+## Pass Summary: 2026-05-23
+
+**Branch Analyzed:** `dev`
+
+**Files Reviewed:**
+- `README.md`
+- `docs/ARCHITECTURE.md` (root and submodule)
+- `docs/SYNC_DESIGN.md`
+- `docs/ENVS.md`
+- `UNFINISHED.md`
+- `babadeluxe-docs/docs/getting-started.md`
+
+**Regressions Found & Fixed:**
+- **Sync Feature:** `docs/SYNC_DESIGN.md` was outdated; updated status to "Implemented (GitHub)", replaced stale `SyncChatEnvelope` with `SyncPayload`, and updated implementation phases.
+- **Environment:** `docs/ENVS.md` was missing conditional optionality details for `VITE_OFFLINE_MODE` and had an outdated Zod validation code example.
+- **Debt Tracking:** `UNFINISHED.md` still listed Ollama and DeepSeek model discovery as unfinished, but they are implemented in the frontend.
+- **Architecture:** `babadeluxe-docs/docs/ARCHITECTURE.md` was missing the "Dependency Injection" section and its 11 injection keys, and the "Persistence" section didn't mention the `ChatRepository` refactor.
+- **Onboarding:** `README.md` and `getting-started.md` were updated to include GitHub Synchronization as a major feature.
+
+**Files Changed:**
+- `README.md`
+- `docs/SYNC_DESIGN.md`
+- `docs/ENVS.md`
+- `UNFINISHED.md`
+- `babadeluxe-docs/docs/ARCHITECTURE.md`
+- `babadeluxe-docs/docs/getting-started.md`
+- `DOC_DRIFT.md`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repo contains the frontend that runs inside the VS Code webview panel. It c
 - **Build:** Vite
 - **Styling:** UnoCSS (Tailwind conventions)
 - **Persistence:** Dexie.js (IndexedDB)
+- **Synchronization:** GitHub (REST)
 - **Real-time:** Socket.io-client
 - **Validation:** Zod + neverthrow
 - **Testing:** Vitest (unit) + Playwright (E2E)

--- a/UNFINISHED.md
+++ b/UNFINISHED.md
@@ -8,10 +8,6 @@ This document tracks identified TODOs, FIXMEs, and incomplete implementations wi
 
 - **OAuth Callback handling**: While basic OAuth is implemented, some edge cases in session synchronization during redirect might still need attention (ref: `AuthCallbackView.vue`).
 
-### Model Integration
-
-- **Ollama & DeepSeek**: Support for Ollama and DeepSeek models is implemented in the frontend (`src/composables/use-models-socket.ts`) including discovery logic, though full end-to-end functionality depends on backend availability. (`src/composables/use-models-socket.ts`)
-
 ## Technical Debt / Refactoring
 
 
@@ -32,4 +28,3 @@ This document tracks identified TODOs, FIXMEs, and incomplete implementations wi
 ## Scan Results (Raw TODOs)
 
 - `src/composables/use-prompts-socket.ts`: `// TODO Check if the shared types are correct, because this cast is weird`
-- `src/composables/use-models-socket.ts`: `ollama: [], // TODO Implement ollama and deepseek`

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -43,6 +43,7 @@ export function validateEnvConfig(
   const result = envConfigSchema.safeParse(env)
 
   if (!result.success) {
+    // Build a human-readable message from the structured issue list
     const message = result.error.issues
       .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
       .join('; ')
@@ -56,13 +57,18 @@ export function validateEnvConfig(
 The schema uses `superRefine` to enforce conditional requirements:
 
 ```ts
+const offlineModeSchema = z
+  .enum(['true', 'false'])
+  .optional()
+  .transform((value) => value === 'true')
+
 const envConfigSchema = z
   .object({
     VITE_NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
-    VITE_OFFLINE_MODE: z.enum(['true', 'false']).optional().transform(v => v === 'true'),
     VITE_SUPABASE_URL: z.string().url().optional(),
     VITE_SUPABASE_ANON_KEY: z.string().min(1).optional(),
     VITE_SOCKET_URL: z.string().url().optional(),
+    VITE_OFFLINE_MODE: offlineModeSchema,
     VITE_GA_MEASUREMENT_ID: z.string().min(1).optional(),
     VITE_STATSIG_CLIENT_KEY: z.string().min(1).optional(),
   })

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -2,7 +2,7 @@
 
 **Feature:** Multi-backend chat synchronisation (GitHub, WebDAV, SFTP)  
 **Repo:** BabaDeluxe/babadeluxe-webview  
-**Status:** Design / Pre-implementation  
+**Status:** Implemented (GitHub) / In Progress (WebDAV, SFTP)
 **Author:** simwai
 
 ---
@@ -61,30 +61,23 @@ chats/
 
 `_manifest.json` exists so a sync can detect deletions without fetching every file.
 
-### 3.2 Chat envelope
+### 3.2 Sync Payload
+
+The implementation uses a `SyncPayload` which includes both the conversation metadata and its messages.
 
 ```ts
-interface SyncChatEnvelope {
-  schemaVersion: 1
-  id: string // UUID v4, stable across devices
-  version: number // monotonically increasing integer, device-local counter
-  updatedAt: string // ISO 8601, informational only — NOT used for conflict resolution
-  deviceId: string // random UUID generated once per installation
-  payload: Chat // the actual chat data from src/database/
+export type SyncPayload = {
+  syncId: string
+  conversation: Conversation & { syncId: string; syncVersion: number }
+  messages: Message[]
+  syncVersion: number
+  deviceId: string
+  deletedAt?: string // ISO 8601 tombstone for deletions
 }
 ```
 
-**Why `version` instead of `updatedAt` for conflicts?**  
+**Why `syncVersion` instead of `updatedAt` for conflicts?**
 Clocks skew. Two devices with clock drift > a few seconds will silently overwrite each other with timestamp-based LWW. A version counter incremented on every write is strictly monotonic per device and survives system clock changes.
-
-### 3.3 Manifest
-
-```ts
-interface SyncManifest {
-  schemaVersion: 1
-  entries: Record<string, { version: number; deviceId: string; deletedAt?: string }>
-}
-```
 
 ---
 
@@ -317,11 +310,11 @@ Credentials are **never** stored in plaintext in `localStorage` or `IndexedDB`. 
 
 ## 12. Implementation Phases
 
-**Phase 1 — Core + GitHub adapter** (highest value, lowest complexity)
+**Phase 1 — Core + GitHub adapter** (✅ COMPLETED)
 
-- `ISyncAdapter`, `SyncManager`, `SyncQueue`, `manifest-differ`, `conflict-resolver`
+- `ISyncAdapter`, `SyncManager`, `SyncQueue`, `conflict-resolver`
 - `GitHubSyncAdapter`
-- `sync-store.ts` with basic UI indicators
+- `use-sync-store.ts` with basic UI indicators
 
 **Phase 2 — WebDAV adapter**
 


### PR DESCRIPTION
Performed a comprehensive documentation regression-prevention pass on the `dev` branch. Identified and fixed stale information in `README.md`, `docs/SYNC_DESIGN.md`, `docs/ENVS.md`, `UNFINISHED.md`, and within the `babadeluxe-docs` submodule (`ARCHITECTURE.md` and `getting-started.md`). The updates ensure that documentation accurately reflects current codebase behaviors, including the implemented GitHub synchronization feature, the `ChatRepository` refactor, and the latest environment variable validation logic. All findings and fixes are documented in `DOC_DRIFT.md`.

---
*PR created automatically by Jules for task [9396129318614852522](https://jules.google.com/task/9396129318614852522) started by @simwai*