### PR TITLE
Increase split pane resizer touch zone

### DIFF
--- a/src/components/PromptLayout.vue
+++ b/src/components/PromptLayout.vue
@@ -14,7 +14,7 @@
     <div
       class="relative flex items-center justify-center flex-shrink-0 group touch-none select-none"
       :class="[
-        direction === 'vertical' ? 'cursor-row-resize' : 'cursor-col-resize',
+        direction === 'vertical' ? 'py-3 cursor-row-resize' : 'px-3 cursor-col-resize',
         isDragging ? 'bg-accent/10' : '',
       ]"
       @pointerdown="$emit('start-dragging', $event)"

--- a/src/views/HistoryView.vue
+++ b/src/views/HistoryView.vue
@@ -59,7 +59,7 @@
 
           <!-- Resizer Handle -->
           <div
-            class="relative flex items-center justify-center flex-shrink-0 cursor-row-resize group touch-none select-none"
+            class="relative flex items-center justify-center flex-shrink-0 cursor-row-resize group touch-none select-none py-3"
             :class="{ 'bg-accent/10': verticalIsDragging }"
             @pointerdown="verticalStartDragging"
           >
@@ -122,7 +122,7 @@
 
           <!-- Resizer Handle -->
           <div
-            class="relative flex items-center justify-center cursor-col-resize group touch-none select-none"
+            class="relative flex items-center justify-center cursor-col-resize group touch-none select-none px-3"
             :class="{ 'bg-accent/10': splitIsDragging }"
             @pointerdown="splitStartDragging"
           >


### PR DESCRIPTION
Increased the interactive area of resizer handles in HistoryView and the reusable PromptLayout component. On mobile (vertical stack), a vertical padding (py-3) was added, and on desktop (horizontal split), a horizontal padding (px-3) was added. This improves accessibility and ease of use when resizing panes.

---
*PR created automatically by Jules for task [8638112356439317290](https://jules.google.com/task/8638112356439317290) started by @simwai*