### PR TITLE
docs: documentation regression-prevention pass

### DIFF
--- a/DOC_DRIFT.md
+++ b/DOC_DRIFT.md
@@ -27,6 +27,32 @@ This file documents discrepancies between the codebase implementation and the pr
 
 ---
 
+## Pass Summary: 2025-05-24
+
+**Branch Analyzed:** `dev`
+
+**Files Reviewed:**
+- `README.md`
+- `docs/AUTH.md`
+- `docs/ENVS.md`
+- `babadeluxe-docs/docs/ARCHITECTURE.md`
+- `src/auth/supabase-auth-provider.ts`
+- `src/views/LoginView.vue`
+
+**Regressions Found & Fixed:**
+- **Authentication:** `docs/AUTH.md` and `README.md` were missing Google OAuth support, despite it being implemented and used in `LoginView.vue`.
+- **Environment:** `docs/ENVS.md` was missing `VITE_APP_URL`, which is used for canonical OAuth redirects in `SupabaseAuthProvider.ts`.
+- **Architecture (Submodule):** `babadeluxe-docs/docs/ARCHITECTURE.md` was significantly out of sync with the root architecture doc, missing the entire Dependency Injection section and the `ChatRepository` refactor details.
+
+**Files Changed:**
+- `README.md`
+- `docs/AUTH.md`
+- `docs/ENVS.md`
+- `babadeluxe-docs/docs/ARCHITECTURE.md`
+- `DOC_DRIFT.md`
+
+---
+
 ## Pass Summary: 2025-05-22
 
 **Branch Analyzed:** `dev`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ flowchart LR
 Two strategies depending on where the webview runs:
 
 - **Embedded in VS Code** — auth tokens are bridged from the extension host via `useVsCodeAuth`, no re-login needed
-- **Standalone browser** — standard Supabase PKCE OAuth flow (GitHub / Email)
+- **Standalone browser** — standard Supabase PKCE OAuth flow (GitHub / Google / Email)
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'background': '#13111a', 'primaryColor': '#2a1758', 'primaryTextColor': '#e2d9f3', 'primaryBorderColor': '#7c3aed', 'lineColor': '#7c3aed', 'secondaryColor': '#1a0f3a', 'tertiaryColor': '#0f1a2a', 'edgeLabelBackground': '#1a1030', 'actorBkg': '#2a1758', 'actorBorder': '#7c3aed', 'actorTextColor': '#e2d9f3', 'actorLineColor': '#7c3aed', 'signalColor': '#c4b5fd', 'signalTextColor': '#e2d9f3', 'labelBoxBkgColor': '#1a0f3a', 'labelBoxBorderColor': '#4c1d95', 'labelTextColor': '#c4b5fd', 'loopTextColor': '#e2d9f3', 'noteBkgColor': '#1a0f3a', 'noteTextColor': '#c4b5fd', 'noteBorderColor': '#4c1d95', 'activationBkgColor': '#4c1d95', 'activationBorderColor': '#7c3aed', 'sequenceNumberColor': '#e2d9f3', 'fontFamily': 'monospace'}}}%%
@@ -140,7 +140,7 @@ sequenceDiagram
     rect rgb(15, 26, 42)
         note right of User: Scenario 2 — Standalone Browser
         User->>Webview: Clicks Login
-        Webview->>Supabase: OAuth Flow (PKCE / implicit)
+        Webview->>Supabase: OAuth Flow (PKCE)
         Supabase-->>Webview: Redirect to /auth/callback
         Webview->>Supabase: exchangeCodeForSession / setSession
         Webview->>Webview: verifySession() — confirm getSession() != null

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -17,10 +17,10 @@ When embedded, the extension host already holds a valid GitHub session from the 
 
 ## Supabase PKCE OAuth
 
-For standalone browser usage (local dev, staging), a standard PKCE flow is used:
+For standalone browser usage (local dev, staging), a standard PKCE flow is used for both **GitHub** and **Google**:
 
-1. User clicks Login → `supabase.auth.signInWithOAuth({ provider: 'github', flowType: 'pkce' })`
-2. GitHub redirects back to the webview with an auth code
+1. User clicks Login → `supabase.auth.signInWithOAuth({ provider: 'github' | 'google', flowType: 'pkce' })`
+2. The provider redirects back to the webview (via `VITE_APP_URL` or `window.location.origin`) with an auth code
 3. Supabase exchanges the code for a session and access token
 4. Access token is passed to the Socket.io connection
 

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -13,6 +13,7 @@ All environment variables are validated at boot time via Zod in `src/env-validat
 | `VITE_SOCKET_URL`         | ❌ optional                        | Socket.io backend base URL (`http://localhost:3000` in dev)      |
 | `VITE_GA_MEASUREMENT_ID`  | ❌ optional                        | Google Analytics 4 measurement ID (`G-XXXXXXXXXX`)               |
 | `VITE_STATSIG_CLIENT_KEY` | ❌ optional                        | Statsig client SDK key for feature flags                         |
+| `VITE_APP_URL`            | ❌ optional                        | Canonical deployment origin for OAuth redirects                  |
 
 > **Offline mode:** when `VITE_OFFLINE_MODE=true`, `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are not required and the app runs fully without network auth.
 


### PR DESCRIPTION
This PR performs a documentation regression-prevention pass on the `dev` branch. It addresses several concrete regressions where the documentation was out of sync with the codebase:

- **Authentication:** Added Google OAuth support to `README.md` and `docs/AUTH.md`, reflecting its implementation in `SupabaseAuthProvider.ts` and `LoginView.vue`.
- **Environment:** Added `VITE_APP_URL` to `docs/ENVS.md`, which is used for canonical OAuth redirects.
- **Architecture (Submodule):** Synchronized `babadeluxe-docs/docs/ARCHITECTURE.md` with the root architecture document, adding the missing Dependency Injection section and `ChatRepository` refactor details.
- **Audit Log:** Updated `DOC_DRIFT.md` with a summary of the findings and fixes from this pass (2025-05-24).

All changes are documentation-only and do not affect application logic or tests.

---
*PR created automatically by Jules for task [15706565847625851639](https://jules.google.com/task/15706565847625851639) started by @simwai*