### PR TITLE
fix: replace local type/constant workarounds with @babadeluxe/shared imports

### DIFF
--- a/EXTERNAL_CHANGES.md
+++ b/EXTERNAL_CHANGES.md
@@ -6,24 +6,35 @@ The following changes are required in external packages to support the current B
 
 ### Consolidation of Feature Branches
 
-I have consolidated the following feature branches in the `babadeluxe-shared` repository into a single coherent state:
+✅ **Resolved** — [babadeluxe-shared PR #7](https://github.com/BabaDeluxe/babadeluxe-shared/pull/7) (`feat/temperature-per-model-v2`) consolidates:
 
 - `feat/prompt-injection-settings`
 - `feat/temperature-per-model`
 
-### Missing Exports
+### Previously Missing Exports
 
-The following types and constants are currently missing from the exported API of `@babadeluxe/shared` but are required by `PromptInjectionSettings.vue` and `prompt-injection-service.ts`:
+✅ **All resolved in shared PR #7.** The following are now exported from `@babadeluxe/shared`:
 
-- `PromptInjectionMode` (type)
-- `PromptInjectionPosition` (type)
-- `PROMPT_INJECTION_DEFAULTS` (constant)
-- `ModelTemperatures` (type)
-- `DEFAULT_TEMPERATURE` (constant)
-- Helper functions: `getModelTemperature`, `setModelTemperature`, `resetModelTemperature`.
+| Export | Kind | Notes |
+|---|---|---|
+| `PromptInjectionMode` | type | |
+| `PromptInjectionPosition` | type | |
+| `promptInjectionDefaults` | const | camelCase (was `PROMPT_INJECTION_DEFAULTS` in earlier drafts) |
+| `ModelTemperatures` | type | |
+| `defaultTemperature` | const | camelCase (was `DEFAULT_TEMPERATURE` in earlier drafts) |
+| `getModelTemperature` | function | |
+| `setModelTemperature` | function | |
+| `resetModelTemperature` | function | |
 
-**Action Taken**:
-I have manually implemented these types and defaults in `src/services/prompt-injection-service.ts` within the webview repository as a temporary workaround.
+### Webview Workarounds Removed
 
-**Action Required**:
-A PR should be opened in `@babadeluxe/shared` merging `feat/prompt-injection-settings` and `feat/temperature-per-model` and ensuring all types/helpers are properly exported. I have verified the merge logic locally.
+This PR removes the local workarounds that were in place while shared PR #7 was pending:
+
+- `src/services/prompt-injection-service.ts` — local `PromptInjectionMode`, `PromptInjectionPosition`, `promptInjectionDefaults` definitions removed; now re-exported from `@babadeluxe/shared`
+- `src/views/SettingsView.vue` — inline `ModelTemperatures` type, `setModelTemperature`, and `resetModelTemperature` copies removed; imported from `@babadeluxe/shared`
+- `getTemperatureForModel` now returns `defaultTemperature` (1.0) instead of `undefined` when no override exists, matching the shared helper contract
+
+### Action Required Before Merging This PR
+
+- Merge [babadeluxe-shared PR #7](https://github.com/BabaDeluxe/babadeluxe-shared/pull/7) first
+- Bump `@babadeluxe/shared` to the version that includes PR #7

--- a/src/services/prompt-injection-service.ts
+++ b/src/services/prompt-injection-service.ts
@@ -3,22 +3,18 @@
  *
  * Pure, side-effect-free logic for building the final message array
  * that gets sent to the LLM, respecting the user's injection settings.
+ *
+ * Types and defaults are sourced from @babadeluxe/shared — do not duplicate them here.
  */
 
-export type PromptInjectionMode =
-  | 'always'
-  | 'first-message'
-  | 'every-x-messages'
-  | 'on-prompt-change'
-  | 'manual'
-export type PromptInjectionPosition = 'system' | 'user-prefix' | 'user-suffix'
+export type {
+  PromptInjectionMode,
+  PromptInjectionPosition,
+} from '@babadeluxe/shared'
+export { promptInjectionDefaults } from '@babadeluxe/shared'
 
-export const promptInjectionDefaults = {
-  mode: 'first-message' as PromptInjectionMode,
-  position: 'system' as PromptInjectionPosition,
-  interval: 5,
-  includeHistory: true,
-}
+import type { PromptInjectionMode, PromptInjectionPosition } from '@babadeluxe/shared'
+import { promptInjectionDefaults } from '@babadeluxe/shared'
 
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant'
@@ -123,10 +119,4 @@ export function resolveInjectionContext(
     promptChanged: partial.promptChanged ?? false,
     promptText: partial.promptText,
   }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function validateSetting(key: string, value: unknown): { success: boolean; error?: string } {
-  // Mock validation for now
-  return { success: true }
 }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -275,7 +275,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { ResultAsync } from 'neverthrow'
-import { validateSetting } from '@babadeluxe/shared'
+import {
+  validateSetting,
+  type ModelTemperatures,
+  setModelTemperature,
+  resetModelTemperature,
+  defaultTemperature,
+} from '@babadeluxe/shared'
 import { useSettings } from '@/composables/use-settings'
 import { useModelsSocket } from '@/composables/use-models-socket'
 import { useApiKeyManagement } from '@/composables/use-api-key-management'
@@ -301,22 +307,6 @@ import { promptInjectionDefaults } from '@/services/prompt-injection-service'
 type Model = {
   label: string
   value: string
-}
-
-type ModelTemperatures = Record<string, number>
-
-function setModelTemperature(
-  current: ModelTemperatures,
-  modelValue: string,
-  value: number
-): ModelTemperatures {
-  return { ...current, [modelValue]: value }
-}
-
-function resetModelTemperature(current: ModelTemperatures, modelValue: string): ModelTemperatures {
-  const next = { ...current }
-  delete next[modelValue]
-  return next
 }
 
 const logger = safeInject(LOGGER_KEY)
@@ -547,8 +537,8 @@ const modelTemperatures = computed<ModelTemperatures>(() => {
   return (s?.settingValue as ModelTemperatures) ?? {}
 })
 
-function getTemperatureForModel(modelValue: string): number | undefined {
-  return modelTemperatures.value[modelValue]
+function getTemperatureForModel(modelValue: string): number {
+  return modelTemperatures.value[modelValue] ?? defaultTemperature
 }
 
 async function persistTemperatures(next: ModelTemperatures): Promise<void> {


### PR DESCRIPTION
## Summary

Now that [babadeluxe-shared PR #7](https://github.com/BabaDeluxe/babadeluxe-shared/pull/7) exports all the required types and helpers, this PR removes the local workarounds that were duplicating that logic inside the webview.

## What changed

### `src/services/prompt-injection-service.ts`
- Removed local definitions of `PromptInjectionMode`, `PromptInjectionPosition`, and `promptInjectionDefaults`
- Re-exports them from `@babadeluxe/shared` so all consumers in the webview keep working without import changes
- Removed the dead `validateSetting` mock at the bottom (the real one is imported from shared in `SettingsView.vue`)

### `src/views/SettingsView.vue`
- Removed inline `ModelTemperatures` type, `setModelTemperature`, and `resetModelTemperature` function copies
- Imports `ModelTemperatures`, `setModelTemperature`, `resetModelTemperature`, and `defaultTemperature` from `@babadeluxe/shared`
- `getTemperatureForModel` now returns `defaultTemperature` (1.0) instead of `undefined` when no per-model override is set — aligns with the shared helper contract and avoids `ModelTemperatureRow` receiving `undefined`

### `EXTERNAL_CHANGES.md`
- All items marked ✅ resolved
- Documents the final camelCase export names (`promptInjectionDefaults`, `defaultTemperature`) vs. the SCREAMING_SNAKE_CASE names referenced in earlier drafts
- Notes the merge order requirement: shared PR #7 must land and be bumped before this PR is merged

## Merge order

> ⚠️ **Merge shared PR #7 first**, then bump `@babadeluxe/shared` in this repo, then merge this PR.

## Testing

- [ ] `pnpm type-check` passes after bumping `@babadeluxe/shared`
- [ ] Settings view loads and all prompt injection + temperature controls work
- [ ] `ModelTemperatureRow` receives `1.0` (not `undefined`) for models with no override