### PR TITLE
fix(sync): persist syncVersion on every push + flush pending on syncNow

### DIFF
--- a/src/sync/sync-manager.ts
+++ b/src/sync/sync-manager.ts
@@ -1,5 +1,6 @@
 import { ok, err, type Result } from 'neverthrow'
 import { v4 as uuidv4 } from 'uuid'
+import { useTimeoutFn } from '@vueuse/core'
 import type { AppDb } from '@/database/app-db'
 import type { Conversation, Message } from '@/database/types'
 import { SyncError as AppSyncError } from '@/errors'
@@ -21,13 +22,15 @@ type DbMessage = {
   contextReferences?: string
 }
 
+type PendingTimer = ReturnType<typeof useTimeoutFn>
+
 const flushDebounceMs = 2000
 
 export class SyncManager {
   private _adapter: ISyncAdapter | null = null
   private _statusHandlers: StatusHandler[] = []
   private _conflictHandlers: ConflictHandler[] = []
-  private _pending = new Map<number, ReturnType<typeof setTimeout>>()
+  private _pending = new Map<number, PendingTimer>()
 
   constructor(
     private readonly _db: AppDb,
@@ -49,27 +52,43 @@ export class SyncManager {
 
   notifyChanged(conversationId: number): void {
     const existing = this._pending.get(conversationId)
-    if (existing) clearTimeout(existing)
+    if (existing) {
+      existing.stop()
+      existing.start()
+      return
+    }
 
-    const timer = setTimeout(() => {
+    const timer = useTimeoutFn(() => {
       this._pending.delete(conversationId)
       void this._pushOne(conversationId)
-    }, flushDebounceMs)
+    }, flushDebounceMs, { immediate: false })
 
     this._pending.set(conversationId, timer)
+    timer.start()
   }
 
   notifyDeleted(conversationId: number, syncVersion: number): void {
     const existing = this._pending.get(conversationId)
-    if (existing) clearTimeout(existing)
+    if (existing) {
+      existing.stop()
+      this._pending.delete(conversationId)
+    }
     void this._pushTombstone(conversationId, syncVersion)
   }
 
   async syncNow(): Promise<void> {
+    const pendingIds: number[] = []
+
     for (const [id, timer] of this._pending) {
-      clearTimeout(timer)
-      this._pending.delete(id)
+      if (timer.isPending.value) {
+        timer.stop()
+        pendingIds.push(id)
+      }
     }
+    this._pending.clear()
+
+    // Flush all pending pushes before pulling to avoid overwriting local changes
+    await Promise.all(pendingIds.map((id) => this._pushOne(id)))
     await this.pullAll()
   }
 
@@ -256,9 +275,8 @@ export class SyncManager {
     const syncId = conv.syncId ?? uuidv4()
     const syncVersion = (conv.syncVersion ?? 0) + 1
 
-    if (!conv.syncId) {
-      await this._db.conversation.update(conversationId, { syncId, syncVersion })
-    }
+    // Always persist the new syncVersion so subsequent pushes increment correctly
+    await this._db.conversation.update(conversationId, { syncId, syncVersion })
 
     const msgResult = await this._db.message
       .where('conversationId')


### PR DESCRIPTION
## Summary

Fixes two bugs in `SyncManager` found during a design review of `src/sync/sync-manager.ts`.

---

## Bug 1 — `syncVersion` not persisted on re-push

**Root cause:** `_buildPayload` only called `db.conversation.update()` on first-time `syncId` assignment (`if (!conv.syncId)`). On every subsequent push, `syncVersion` was incremented in memory but never written back to IndexedDB. This meant two saves on the same conversation would both push `version: 2` instead of `2` then `3`.

**Fix:** Always `await this._db.conversation.update(conversationId, { syncId, syncVersion })` after computing the new version — unconditionally.

---

## Bug 2 — `syncNow()` silently dropped pending pushes

**Root cause:** `syncNow` cancelled all debounce timers and then only called `pullAll()`, never pushing the changes those timers were about to flush. Any unsaved conversation edit in the debounce window was silently lost on manual sync.

**Fix:** Collect all pending IDs before clearing, push them all first, then pull.

---

## Refactor — `useTimeoutFn` replaces manual `setTimeout` Map

The manual `_pending: Map<number, ReturnType<typeof setTimeout>>` + raw `clearTimeout` is replaced with `useTimeoutFn` from `@vueuse/core`, which exposes `{ isPending, start, stop }` per timer. This:

- Makes the flush in `syncNow` readable via `timer.isPending.value`
- Removes the need to manually manage `clearTimeout` handles
- Is safe to use in a plain class — `useTimeoutFn` uses no Vue lifecycle hooks internally

---

## Files changed

- `src/sync/sync-manager.ts`

## Testing

- [ ] Save a conversation twice rapidly — confirm remote receives version 2, then 3
- [ ] Trigger `syncNow()` mid-debounce — confirm the pending change is pushed before pull
- [ ] Delete a conversation with a pending edit — confirm tombstone wins and no ghost push