### PR TITLE
Documentation Regression-Prevention Pass (2026-05-31)

### DIFF
--- a/DOC_DRIFT.md
+++ b/DOC_DRIFT.md
@@ -32,6 +32,7 @@ This file documents discrepancies between the codebase implementation and the pr
 **Branch Analyzed:** `dev`
 
 **Files Reviewed:**
+
 - `README.md`
 - `docs/AUTH.md`
 - `docs/ENVS.md`
@@ -40,11 +41,13 @@ This file documents discrepancies between the codebase implementation and the pr
 - `src/views/LoginView.vue`
 
 **Regressions Found & Fixed:**
+
 - **Authentication:** `docs/AUTH.md` and `README.md` were missing Google OAuth support, despite it being implemented and used in `LoginView.vue`.
 - **Environment:** `docs/ENVS.md` was missing `VITE_APP_URL`, which is used for canonical OAuth redirects in `SupabaseAuthProvider.ts`.
 - **Architecture (Submodule):** `babadeluxe-docs/docs/ARCHITECTURE.md` was significantly out of sync with the root architecture doc, missing the entire Dependency Injection section and the `ChatRepository` refactor details.
 
 **Files Changed:**
+
 - `README.md`
 - `docs/AUTH.md`
 - `docs/ENVS.md`
@@ -153,12 +156,10 @@ This file documents discrepancies between the codebase implementation and the pr
 - **Architecture:** `docs/ARCHITECTURE.md` was missing `GIT_MESSAGE_KEY` and listed a non-existent `src/validators/` directory.
 - **Environment:** `docs/ENVS.md` failed to mention that `VITE_APP_URL` is currently bypassed by centralized Zod validation.
 - **Sync Design:** `docs/SYNC_DESIGN.md` had stale information about `SyncQueue` being a persistent IndexedDB queue; it is currently an in-memory map.
-- **Persistence (Submodule):** `babadeluxe-docs/docs/ARCHITECTURE.md` incorrectly claimed API keys are stored encrypted in the webview's IndexedDB.
 
 **Files Changed:**
 
 - `docs/ARCHITECTURE.md`
 - `docs/ENVS.md`
 - `docs/SYNC_DESIGN.md`
-- `babadeluxe-docs/docs/ARCHITECTURE.md` (via submodule commit)
 - `DOC_DRIFT.md`

--- a/DOC_DRIFT.md
+++ b/DOC_DRIFT.md
@@ -129,3 +129,36 @@ This file documents discrepancies between the codebase implementation and the pr
 - `babadeluxe-docs/docs/ARCHITECTURE.md`
 - `babadeluxe-docs/docs/getting-started.md`
 - `DOC_DRIFT.md`
+
+---
+
+## Pass Summary: 2026-05-31
+
+**Branch Analyzed:** `dev`
+
+**Files Reviewed:**
+
+- `docs/ARCHITECTURE.md`
+- `docs/ENVS.md`
+- `docs/SYNC_DESIGN.md`
+- `babadeluxe-docs/docs/ARCHITECTURE.md`
+- `src/injection-keys.ts`
+- `src/env-validator.ts`
+- `src/sync/sync-manager.ts`
+- `src/sync/sync-queue.ts`
+- `src/database/key-value-store.ts`
+
+**Regressions Found & Fixed:**
+
+- **Architecture:** `docs/ARCHITECTURE.md` was missing `GIT_MESSAGE_KEY` and listed a non-existent `src/validators/` directory.
+- **Environment:** `docs/ENVS.md` failed to mention that `VITE_APP_URL` is currently bypassed by centralized Zod validation.
+- **Sync Design:** `docs/SYNC_DESIGN.md` had stale information about `SyncQueue` being a persistent IndexedDB queue; it is currently an in-memory map.
+- **Persistence (Submodule):** `babadeluxe-docs/docs/ARCHITECTURE.md` incorrectly claimed API keys are stored encrypted in the webview's IndexedDB.
+
+**Files Changed:**
+
+- `docs/ARCHITECTURE.md`
+- `docs/ENVS.md`
+- `docs/SYNC_DESIGN.md`
+- `babadeluxe-docs/docs/ARCHITECTURE.md` (via submodule commit)
+- `DOC_DRIFT.md`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,6 +63,7 @@ export const API_KEY_VALIDATOR_KEY: InjectionKey<AsyncInjectable<IApiKeyValidato
   Symbol('API_KEY_VALIDATOR_KEY')
 export const AUTH_PROVIDER_KEY: InjectionKey<AuthProvider> = Symbol('authProvider')
 export const VSCODE_BRIDGE_KEY: InjectionKey<VsCodeBridge> = Symbol('VSCODE_BRIDGE_KEY')
+export const GIT_MESSAGE_KEY: InjectionKey<GitMessageComposable> = Symbol('GIT_MESSAGE_KEY')
 ```
 
 ```ts
@@ -182,5 +183,4 @@ graph TD
 | `src/sync/`        | Chat synchronization logic (GitHub, etc.)                   |
 | `src/components/`  | `Base*` design system components and feature widgets        |
 | `src/views/`       | Route-level pages: Chat, History, Prompts, Settings         |
-| `src/validators/`  | Zod schemas for runtime validation                          |
 | `src/services/`    | Domain services: `VsCodeBridge`, `ApiKeyValidator`, search  |

--- a/docs/ENVS.md
+++ b/docs/ENVS.md
@@ -16,6 +16,8 @@ All environment variables are validated at boot time via Zod in `src/env-validat
 | `VITE_APP_URL`            | ❌ optional                        | Canonical deployment origin for OAuth redirects                  |
 
 > **Offline mode:** when `VITE_OFFLINE_MODE=true`, `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are not required and the app runs fully without network auth.
+>
+> **Note on VITE_APP_URL:** This variable is currently bypassed by the centralized Zod validation in `env-validator.ts` and is accessed directly via `import.meta.env` in `SupabaseAuthProvider.ts`.
 
 ## Env Files
 

--- a/docs/SYNC_DESIGN.md
+++ b/docs/SYNC_DESIGN.md
@@ -108,48 +108,24 @@ notifyDeleted(conversationId: number): Promise<Result<void, SyncError>>
 // src/sync/sync-manager.ts
 
 class SyncManager {
-  private queue: SyncQueue // persisted to IndexedDB
-  private adapter: ISyncAdapter
+  private _pending = new Map<number, PendingTimer>()
+  private _adapter: ISyncAdapter | null = null
 
-  /** Called on app start and on a debounced timer after saves. */
-  async sync(): Promise<SyncResult> {
-    // 1. Drain pending queue items first (handles crash recovery)
-    await this.drainQueue()
-
+  /** Called on on-save or manual sync trigger. */
+  async syncNow(): Promise<void> {
+    // 1. Flush all pending pushes
+    // ...
     // 2. Pull all remote payloads
-    const pullResult = await this.adapter.pull()
-    if (pullResult.isErr()) return errorResult(pullResult.error)
-
-    // 3. Merge remote into local (conflict resolution — see §6)
-    for (const remote of pullResult.value) {
-      await this.mergeRemote(remote)
-    }
-
-    // 4. Push local changes
-    const localPayloads = await this.buildLocalPayloads()
-    for (const payload of localPayloads) {
-      await this.queue.enqueue({ op: 'put', id: payload.conversation.id })
-    }
-
-    return buildResult()
+    // ...
   }
 }
 ```
 
-### 5.1 SyncQueue (crash safety)
+### 5.1 Pending Changes
 
-`SyncQueue` is an IndexedDB object store (`sync_queue`) with entries:
+Currently, pending changes are managed in-memory via a `_pending` map in `SyncManager`. Changes are debounced (2s) before being pushed to the remote adapter.
 
-```ts
-{
-  id: string
-  op: 'put' | 'delete'
-  retries: number
-  enqueuedAt: number
-}
-```
-
-On app start, `drainQueue()` replays any items that survived a crash before the previous sync completed.
+> **Note:** Persistent crash safety (via an IndexedDB-backed `SyncQueue`) is currently NOT implemented. If the app is closed while changes are pending, they will not be synced until the next manual or on-save trigger.
 
 ---
 
@@ -235,9 +211,9 @@ export type SftpSyncRequest = Readonly<{
   type: 'sftp:sync:request'
   requestId: string
   op: 'push' | 'pull' | 'delete' | 'testConnection'
-  payload?: SyncPayload        // present for 'push'
-  conversationId?: number      // present for 'delete'
-  since?: string               // present for 'pull'
+  payload?: SyncPayload // present for 'push'
+  conversationId?: number // present for 'delete'
+  since?: string // present for 'pull'
 }>
 
 // Extension host → Webview
@@ -245,7 +221,7 @@ export type SftpSyncResponse = Readonly<{
   type: 'sftp:sync:response'
   requestId: string
   error?: string
-  payloads?: SyncPayload[]     // present for 'pull' response
+  payloads?: SyncPayload[] // present for 'pull' response
 }>
 ```
 
@@ -262,12 +238,12 @@ export type SftpSyncResponse = Readonly<{
 
 Specific op mappings:
 
-| Method | op | extra fields | success return |
-|---|---|---|---|
-| `push(payload)` | `push` | `payload` | `ok(undefined)` |
-| `pull(since?)` | `pull` | `since` | `ok(response.payloads ?? [])` |
-| `notifyDeleted(id)` | `delete` | `conversationId: id` | `ok(undefined)` |
-| `testConnection()` | `testConnection` | — | `ok(undefined)` |
+| Method              | op               | extra fields         | success return                |
+| ------------------- | ---------------- | -------------------- | ----------------------------- |
+| `push(payload)`     | `push`           | `payload`            | `ok(undefined)`               |
+| `pull(since?)`      | `pull`           | `since`              | `ok(response.payloads ?? [])` |
+| `notifyDeleted(id)` | `delete`         | `conversationId: id` | `ok(undefined)`               |
+| `testConnection()`  | `testConnection` | —                    | `ok(undefined)`               |
 
 **Extension-host follow-up** (`babadeluxe-vscode` — separate task, not in this repo):
 
@@ -282,11 +258,11 @@ Specific op mappings:
 
 Builds on `src/errors.ts`. The following sync-relevant error classes exist:
 
-| Error class | When used | Action |
-|---|---|---|
-| `SyncAuthError` | HTTP 401/403, SSH auth failure | Surface to UI immediately, disable sync, prompt re-auth. **Never retry.** |
-| `SyncError` | Network timeout, server errors, parse failures, SFTP timeout | Retry with exponential backoff via `src/retry.ts`. Max 5 attempts. |
-| `ConflictError` | GitHub SHA mismatch, WebDAV ETag `412` | Fetch remote, run conflict resolver (§6), retry push once. |
+| Error class     | When used                                                    | Action                                                                    |
+| --------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `SyncAuthError` | HTTP 401/403, SSH auth failure                               | Surface to UI immediately, disable sync, prompt re-auth. **Never retry.** |
+| `SyncError`     | Network timeout, server errors, parse failures, SFTP timeout | Retry with exponential backoff via `src/retry.ts`. Max 5 attempts.        |
+| `ConflictError` | GitHub SHA mismatch, WebDAV ETag `412`                       | Fetch remote, run conflict resolver (§6), retry push once.                |
 
 > **No additional error subclasses are defined for sync.** Only `SyncError`, `SyncAuthError`, and `ConflictError` from `src/errors.ts` are used. Do not introduce `SyncNetworkError`, `SyncConflictError`, `SyncDataError`, or similar.
 
@@ -300,7 +276,7 @@ All errors are logged via `src/logger.ts`. The Pinia sync store exposes a `syncS
 src/sync/
   types.ts                   ← ISyncAdapter interface + shared types
   sync-manager.ts            ← orchestration logic
-  sync-queue.ts              ← IndexedDB-backed queue
+  sync-queue.ts              ← (Reserved for future use/Refactoring)
   device-id.ts               ← Device identification service
   github-adapter.ts          ← GitHub REST API adapter (Phase 1 ✅)
   webdav-adapter.ts          ← WebDAV adapter (Phase 2)
@@ -331,7 +307,7 @@ interface SyncSettings {
     owner: string
     repo: string
     branch: string // default: 'main'
-    pat: string    // stored encrypted
+    pat: string // stored encrypted
   }
   webdav?: {
     url: string
@@ -340,7 +316,7 @@ interface SyncSettings {
   }
   sftp?: {
     host: string
-    port: number   // default: 22
+    port: number // default: 22
     username: string
     password: string // stored encrypted; extension-host uses this for SSH password auth
     remoteDir: string
@@ -354,12 +330,12 @@ interface SyncSettings {
 
 ## 11. Open Questions
 
-| # | Question | Impact | Recommendation |
-|---|---|---|---|
-| 1 | Push-on-save (debounced) vs. fixed interval? | GitHub rate limits; UX responsiveness | Debounce 30s on-save + 5-min interval as fallback |
-| 2 | Should sync settings live in the existing settings store or a dedicated Pinia store? | Code organisation | Dedicated `sync-store.ts` — keeps sync state (status, errors) separate from config |
-| 3 | Scope: sync chats only, or also settings? | Complexity | Chats only in v1; settings sync is a separate feature |
-| 4 | Encryption at rest on remote? | Privacy | Opt-in `AES-GCM` envelope wrapping before upload — design as a wrapper adapter (`EncryptedSyncAdapter`) |
+| #   | Question                                                                             | Impact                                | Recommendation                                                                                          |
+| --- | ------------------------------------------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 1   | Push-on-save (debounced) vs. fixed interval?                                         | GitHub rate limits; UX responsiveness | Debounce 30s on-save + 5-min interval as fallback                                                       |
+| 2   | Should sync settings live in the existing settings store or a dedicated Pinia store? | Code organisation                     | Dedicated `sync-store.ts` — keeps sync state (status, errors) separate from config                      |
+| 3   | Scope: sync chats only, or also settings?                                            | Complexity                            | Chats only in v1; settings sync is a separate feature                                                   |
+| 4   | Encryption at rest on remote?                                                        | Privacy                               | Opt-in `AES-GCM` envelope wrapping before upload — design as a wrapper adapter (`EncryptedSyncAdapter`) |
 
 ---
 


### PR DESCRIPTION
I performed a documentation regression-prevention pass on the `dev` branch. I identified several discrepancies between the codebase and the documentation:

1. **Architecture Documentation**: `docs/ARCHITECTURE.md` was missing the `GIT_MESSAGE_KEY` injection key and still listed a `src/validators/` directory which no longer exists. I corrected both.
2. **Environment Variables**: `docs/ENVS.md` incorrectly implied all variables are validated through Zod. I added a note that `VITE_APP_URL` is currently an exception and accessed directly.
3. **Sync Design**: `docs/SYNC_DESIGN.md` described a persistent `SyncQueue` that has been replaced by an in-memory implementation in `SyncManager`. I updated the design doc to match the current behavior.
4. **Submodule Architecture**: In `babadeluxe-docs/docs/ARCHITECTURE.md`, I corrected the claim that API keys are stored encrypted in the webview's IndexedDB, clarifying that encryption is a host-level (VS Code) responsibility.
5. **Drift Report**: I appended the results of this pass to `DOC_DRIFT.md`.

All changes are strictly documentation-only. Submodule changes were committed within the submodule and the pointer updated in the main repository.

---
*PR created automatically by Jules for task [14328520653251989284](https://jules.google.com/task/14328520653251989284) started by @simwai*