### PR TITLE
Fix build errors and linter violations

### DIFF
--- a/lint_output.txt
+++ b/lint_output.txt
@@ -1,0 +1,28 @@
+
+> @babadeluxe/webview@0.1.0 lint /app
+> concurrently "eslint . --ext .ts,.vue --config eslint.config.ts --ignore pnpm-lock.yaml --concurrency auto" "prettier --check "**/*.{ts,vue,html,md}""
+
+[1] Checking formatting...
+[1] All matched files use Prettier code style!
+[1] prettier --check **/*.{ts,vue,html,md} exited with code 0
+[0]
+[0] /app/pnpm-lock.yaml
+[0]   0:0  warning  File ignored because no matching configuration was supplied
+[0]
+[0] /app/src/composables/use-chat-model-selection.ts
+[0]   1:10  error  'computed' is defined but never used  @typescript-eslint/no-unused-vars
+[0]
+[0] /app/src/stores/conversation/use-conversation-list-state.ts
+[0]   9:56  error  'logger' is defined but never used  @typescript-eslint/no-unused-vars
+[0]
+[0] /app/src/stores/conversation/use-message-management.ts
+[0]   1:10  error  'ref' is defined but never used               @typescript-eslint/no-unused-vars
+[0]   3:24  error  'ContextReference' is defined but never used  @typescript-eslint/no-unused-vars
+[0]
+[0] /app/src/views/SettingsView.vue
+[0]   132:34  error  `import()` type annotations are forbidden  @typescript-eslint/consistent-type-imports
+[0]
+[0] ✖ 6 problems (5 errors, 1 warning)
+[0]
+[0] eslint . --ext .ts,.vue --config eslint.config.ts --ignore pnpm-lock.yaml --concurrency auto exited with code 1
+ ELIFECYCLE  Command failed with exit code 1.

--- a/src/App.vue
+++ b/src/App.vue
@@ -204,7 +204,7 @@
 
 <script setup lang="ts">
 import { RouterLink, RouterView, useRouter, useRoute } from 'vue-router'
-import { onErrorCaptured, computed } from 'vue'
+import { provide, onErrorCaptured, computed } from 'vue'
 import IconBabaDeluxe from '@/components/IconBabaDeluxe.vue'
 import BaseButton from '@/components/BaseButton.vue'
 import BaseAvatar from '@/components/BaseAvatar.vue'

--- a/src/composables/use-chat-model-selection.ts
+++ b/src/composables/use-chat-model-selection.ts
@@ -1,4 +1,4 @@
-import { computed, watch, type Ref } from 'vue'
+import { watch, type Ref } from 'vue'
 import { findPreferredModel } from '@/model-preferences'
 import type { ModelItemGroup, ModelItem } from '@/composables/use-models-socket'
 

--- a/src/stores/conversation/use-conversation-list-state.ts
+++ b/src/stores/conversation/use-conversation-list-state.ts
@@ -2,11 +2,10 @@ import { ref } from 'vue'
 import { ok, err, type Result } from 'neverthrow'
 import type { Conversation } from '@/database/types'
 import type { AppDb } from '@/database/app-db'
-import type { AbstractLogger } from '@/logger'
 import type { DbError } from '@/errors'
 import { ChatError } from '@/errors'
 
-export function useConversationListState(appDb: AppDb, logger: AbstractLogger) {
+export function useConversationListState(appDb: AppDb) {
   const conversations = ref<Conversation[]>([])
   const isLoadingConversations = ref(false)
   const messageCountsByConversation = ref<Map<number, number>>(new Map())

--- a/src/stores/conversation/use-message-management.ts
+++ b/src/stores/conversation/use-message-management.ts
@@ -1,6 +1,6 @@
-import { ref, type Ref } from 'vue'
+import { type Ref } from 'vue'
 import { ok, err, type Result } from 'neverthrow'
-import type { Message, ContextReference } from '@/database/types'
+import type { Message } from '@/database/types'
 import type { AppDb } from '@/database/app-db'
 import type { DbError } from '@/errors'
 import { ChatError, MessageNotFoundError } from '@/errors'

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -109,6 +109,11 @@ import { useModelsSocket } from '@/composables/use-models-socket'
 import { useSettings } from '@/composables/use-settings'
 import { useApiKeyManagement } from '@/composables/use-api-key-management'
 import { isOfflineMode } from '@/env-validator'
+import type { IApiKeyValidator } from '@/api-key-validator'
+import type {
+  PromptInjectionMode,
+  PromptInjectionPosition,
+} from '@/services/prompt-injection-service'
 
 const logger = safeInject(LOGGER_KEY)
 const apiKeyValidator = safeInject(API_KEY_VALIDATOR_KEY)
@@ -116,7 +121,7 @@ const supabase = safeInject(SUPABASE_CLIENT_KEY)
 const toasts = useToastStore()
 
 const { settings, upsertSetting, loadSettings } = useSettings()
-const { reloadModels } = useModelsSocket()
+const { reloadModels, groupedModels } = useModelsSocket()
 const { isDark, toggleDark } = useTheme()
 useOllamaSettings()
 
@@ -128,9 +133,7 @@ const currentUserId = ref<string>()
 // resolvedValidator are unreachable while isReady is false.
 const isReady = computed(() => apiKeyValidator.isReady && apiKeyValidator.value !== undefined)
 
-const resolvedValidator = computed(
-  () => apiKeyValidator.value as import('@/api-key-validator').IApiKeyValidator
-)
+const resolvedValidator = computed(() => apiKeyValidator.value as IApiKeyValidator)
 
 const { apiProviders, fieldStates, hydrateFieldStates, handleApiKeyInput } = useApiKeyManagement(
   resolvedValidator,
@@ -160,25 +163,20 @@ const getSettingValue = <T,>(key: string, fallback: T): T => {
   return s !== undefined ? (s.settingValue as T) : fallback
 }
 
-const promptInjectionMode = computed<
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  NonNullable<import('@/services/prompt-injection-service').PromptInjectionMode>
->(() => getSettingValue('promptInjectionMode', promptInjectionDefaults.mode))
+const promptInjectionMode = computed<PromptInjectionMode>(() =>
+  getSettingValue('promptInjectionMode', promptInjectionDefaults.mode)
+)
 const promptInjectionInterval = computed<number>(() =>
   getSettingValue('promptInjectionInterval', promptInjectionDefaults.interval)
 )
-const promptInjectionPosition = computed<
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  NonNullable<import('@/services/prompt-injection-service').PromptInjectionPosition>
->(() => getSettingValue('promptInjectionPosition', promptInjectionDefaults.position))
+const promptInjectionPosition = computed<PromptInjectionPosition>(() =>
+  getSettingValue('promptInjectionPosition', promptInjectionDefaults.position)
+)
 const promptIncludeHistory = computed<boolean>(() =>
   getSettingValue('promptIncludeHistory', promptInjectionDefaults.includeHistory)
 )
 
-const handleInjectionModeChange = async (
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  mode: NonNullable<import('@/services/prompt-injection-service').PromptInjectionMode>
-) => {
+const handleInjectionModeChange = async (mode: PromptInjectionMode) => {
   await upsertSetting('promptInjectionMode', mode, 'string')
 }
 
@@ -188,10 +186,7 @@ const handleIntervalChange = async (value: number) => {
   await upsertSetting('promptInjectionInterval', value, 'number')
 }
 
-const handlePositionChange = async (
-  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  pos: NonNullable<import('@/services/prompt-injection-service').PromptInjectionPosition>
-) => {
+const handlePositionChange = async (pos: PromptInjectionPosition) => {
   await upsertSetting('promptInjectionPosition', pos, 'string')
 }
 
@@ -288,11 +283,7 @@ const handleFieldChange = async (fieldName: string, value: unknown) => {
   toasts.success('Setting saved')
 }
 
-const availableModels = computed<unknown[]>((models) => {
-  const providerGroups = models
-  if (!providerGroups) return []
-  return providerGroups
-})
+const availableModels = computed(() => groupedModels.value.flatMap((group) => group.items))
 
 const modelTemperatures = computed<ModelTemperatures>(() => {
   const s = settings.value.find(

--- a/tests/settings-view.integration.test.ts
+++ b/tests/settings-view.integration.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { reactive } from 'vue'
+import { reactive, ref } from 'vue'
 import type { AsyncInjectable } from '@/injection-keys'
 import { API_KEY_VALIDATOR_KEY, LOGGER_KEY, SUPABASE_CLIENT_KEY } from '@/injection-keys'
 import type { IApiKeyValidator } from '@/api-key-validator'
@@ -32,6 +32,7 @@ vi.mock('@/composables/use-settings', () => ({
 vi.mock('@/composables/use-models-socket', () => ({
   useModelsSocket: () => ({
     models: ref({}),
+    groupedModels: ref([]),
     reloadModels: vi.fn().mockResolvedValue(ok(undefined)),
   }),
 }))

--- a/type_check_output.txt
+++ b/type_check_output.txt
@@ -1,0 +1,10 @@
+
+> @babadeluxe/webview@0.1.0 type-check /app
+> vue-tsc --build
+
+src/App.vue(224,1): error TS2304: Cannot find name 'provide'.
+src/views/SettingsView.vue(69,10): error TS2322: Type 'unknown[]' is not assignable to type 'Model[]'.
+  Type 'unknown' is not assignable to type 'Model'.
+tests/settings-view.integration.test.ts(26,15): error TS2304: Cannot find name 'ref'.
+tests/settings-view.integration.test.ts(34,13): error TS2304: Cannot find name 'ref'.
+ ELIFECYCLE  Command failed with exit code 1.


### PR DESCRIPTION
This PR fixes all open build errors and linter violations identified by `pnpm lint` and `pnpm type-check`.

Key changes:
- **src/App.vue**: Added missing `provide` import.
- **src/composables/use-chat-model-selection.ts**: Removed unused `computed` import.
- **src/stores/conversation/use-conversation-list-state.ts**: Removed unused `logger` parameter and `AbstractLogger` import.
- **src/stores/conversation/use-message-management.ts**: Removed unused `ref` and `ContextReference` imports.
- **src/views/SettingsView.vue**: 
  - Replaced forbidden inline `import()` type annotations with top-level type imports.
  - Correctly destructured `groupedModels` from `useModelsSocket`.
  - Re-implemented `availableModels` computed property to correctly flatten model groups.
- **tests/settings-view.integration.test.ts**:
  - Added missing `ref` import.
  - Updated `useModelsSocket` mock to include `groupedModels` ref, fixing test failures.
- **Formatting**: Ran `pnpm format` to clean up all modified files.

All checks (`lint`, `type-check`, `test-unit`) now pass successfully.

---
*PR created automatically by Jules for task [12939209466271337713](https://jules.google.com/task/12939209466271337713) started by @simwai*