### PR TITLE
Add Visible Reasoning Steps and Ollama Support

### DIFF
--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -10,6 +10,16 @@
         <BaseAvatar :role="role" />
       </template>
 
+      <div
+        v-if="role === 'assistant' && (reasoning || currentReasoning)"
+        class="w-full"
+      >
+        <ChatReasoningBlock
+          :reasoning="reasoning || currentReasoning || ''"
+          :is-streaming="isStreamingReasoning"
+        />
+      </div>
+
       <BaseEditableText
         :content="content"
         :is-editing="isEditing"
@@ -21,7 +31,7 @@
           <MarkdownRenderer
             ref="markdownRef"
             :content="content"
-            :cursor="isStreaming && role === 'assistant'"
+            :cursor="isStreaming && role === 'assistant' && !isStreamingReasoning"
             :is-streaming="isStreaming"
           />
         </template>
@@ -69,7 +79,9 @@ import ChatMessageActions from '@/components/ChatMessageActions.vue'
 import MarkdownRenderer from '@/components/ChatMarkdownRenderer.vue'
 import BaseAvatar from '@/components/BaseAvatar.vue'
 import ContextBadge from '@/components/ContextBadge.vue'
+import ChatReasoningBlock from '@/components/ChatReasoningBlock.vue'
 import { getDisambiguatedPaths } from '@/path-disambiguation'
+import { useChatSocketStore } from '@/stores/use-chat-socket-store'
 
 defineOptions({ inheritAttrs: false })
 
@@ -91,6 +103,13 @@ const props = withDefaults(defineProps<ChatMessageProps>(), {
 })
 
 const emit = defineEmits<ChatMessageEmitter>()
+
+const socketStore = useChatSocketStore()
+const currentReasoning = computed(() => socketStore.reasoningByMessageId.get(props.id))
+const isStreamingReasoning = computed(() => {
+  const state = socketStore.getMessageState(props.id)
+  return !!state?.isStreaming && !props.content
+})
 
 const markdownRef = useTemplateRef<InstanceType<typeof MarkdownRenderer>>('markdownRef')
 const isEditing = ref(false)

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -10,13 +10,16 @@
         <BaseAvatar :role="role" />
       </template>
 
+      <!-- reasoning prop: persisted reasoning loaded from DB by parent.
+           currentReasoning: live reasoning chunks from the socket store during streaming.
+           Both are shown via ChatReasoningBlock; only one will be non-empty at a time. -->
       <div
         v-if="role === 'assistant' && (reasoning || currentReasoning)"
         class="w-full"
       >
         <ChatReasoningBlock
           :reasoning="reasoning || currentReasoning || ''"
-          :is-streaming="isStreamingReasoning"
+          :is-streaming="isInReasoningPhase"
         />
       </div>
 
@@ -31,7 +34,7 @@
           <MarkdownRenderer
             ref="markdownRef"
             :content="content"
-            :cursor="isStreaming && role === 'assistant' && !isStreamingReasoning"
+            :cursor="isStreaming && role === 'assistant' && !isInReasoningPhase"
             :is-streaming="isStreaming"
           />
         </template>
@@ -94,6 +97,10 @@ type ChatMessageEmitter = {
 interface ChatMessageProps extends Message {
   isRewriteEnabled?: boolean
   isEditEnabled?: boolean
+  /** Persisted reasoning text loaded from the database by the parent component.
+   *  Pass `message.reasoning` from the loaded Message record.
+   *  During live streaming this will be undefined; live chunks come from the socket store instead. */
+  reasoning?: string
 }
 
 const props = withDefaults(defineProps<ChatMessageProps>(), {
@@ -105,8 +112,12 @@ const props = withDefaults(defineProps<ChatMessageProps>(), {
 const emit = defineEmits<ChatMessageEmitter>()
 
 const socketStore = useChatSocketStore()
-const currentReasoning = computed(() => socketStore.reasoningByMessageId.get(props.id))
-const isStreamingReasoning = computed(() => {
+const currentReasoning = computed(() => socketStore.reasoningByMessageId.value.get(props.id))
+
+/** True while the model is in the reasoning phase:
+ *  socket is actively streaming AND no final content has arrived yet (`!props.content`).
+ *  Once content starts flowing, the reasoning phase is over and the cursor moves to the main block. */
+const isInReasoningPhase = computed(() => {
   const state = socketStore.getMessageState(props.id)
   return !!state?.isStreaming && !props.content
 })
@@ -153,7 +164,7 @@ const contextBadges = computed(() => {
     if (!isFile) {
       const sanitizedSnippet = ref.snippetText.trim().replace(/\s+/g, ' ')
       subtitle =
-        sanitizedSnippet.length > 60 ? `${sanitizedSnippet.slice(0, 60)}…` : sanitizedSnippet
+        sanitizedSnippet.length > 60 ? `${sanitizedSnippet.slice(0, 60)}\u2026` : sanitizedSnippet
       tooltip = path ? `${path}\n\n${ref.snippetText}` : ref.snippetText
     }
 

--- a/src/components/ChatReasoningBlock.vue
+++ b/src/components/ChatReasoningBlock.vue
@@ -14,7 +14,7 @@
         class="w-2 h-2 rounded-full bg-primary animate-pulse"
       />
       <span class="text-sm font-medium text-secondary-foreground/70">
-        {{ isStreaming ? 'Thinking…' : 'Reasoning' }}
+        {{ isStreaming ? 'Thinking\u2026' : 'Reasoning' }}
       </span>
       <span
         v-if="tokenCount > 0"
@@ -46,10 +46,11 @@ const props = defineProps<{
   isStreaming: boolean
 }>()
 
-const tokenCount = computed(() => {
-  // Simple heuristic: 1 token ~= 4 characters for English
-  return Math.ceil(props.reasoning.length / 4)
-})
+/** Average characters per token for English prose (cl100k / tiktoken heuristic).
+ *  Not accurate for code-heavy content or CJK languages — display only, not used for billing. */
+const CHARS_PER_TOKEN = 4
+
+const tokenCount = computed(() => Math.ceil(props.reasoning.length / CHARS_PER_TOKEN))
 </script>
 
 <style scoped>

--- a/src/components/ChatReasoningBlock.vue
+++ b/src/components/ChatReasoningBlock.vue
@@ -1,0 +1,59 @@
+<template>
+  <details
+    v-if="reasoning"
+    :open="isStreaming"
+    class="reasoning-block mb-3 border border-border rounded-lg bg-secondary/30 overflow-hidden"
+    data-testid="reasoning-block"
+  >
+    <summary
+      class="reasoning-summary cursor-pointer p-2 flex items-center gap-2 hover:bg-secondary/50 transition-colors list-none"
+      data-testid="reasoning-summary"
+    >
+      <div
+        v-if="isStreaming"
+        class="w-2 h-2 rounded-full bg-primary animate-pulse"
+      />
+      <span class="text-sm font-medium text-secondary-foreground/70">
+        {{ isStreaming ? 'Thinking…' : 'Reasoning' }}
+      </span>
+      <span
+        v-if="tokenCount > 0"
+        class="ml-auto text-xs text-secondary-foreground/50 font-mono"
+        data-testid="reasoning-tokens"
+      >
+        {{ tokenCount }} tokens
+      </span>
+    </summary>
+    <div
+      class="reasoning-body p-3 pt-0 text-sm text-secondary-foreground/80 leading-relaxed"
+      data-testid="reasoning-content"
+    >
+      <MarkdownRenderer
+        :content="reasoning"
+        :cursor="isStreaming"
+        :is-streaming="isStreaming"
+      />
+    </div>
+  </details>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import MarkdownRenderer from '@/components/ChatMarkdownRenderer.vue'
+
+const props = defineProps<{
+  reasoning: string
+  isStreaming: boolean
+}>()
+
+const tokenCount = computed(() => {
+  // Simple heuristic: 1 token ~= 4 characters for English
+  return Math.ceil(props.reasoning.length / 4)
+})
+</script>
+
+<style scoped>
+.reasoning-summary::-webkit-details-marker {
+  display: none;
+}
+</style>

--- a/src/components/settings/OllamaSection.vue
+++ b/src/components/settings/OllamaSection.vue
@@ -1,0 +1,146 @@
+<template>
+  <div
+    class="space-y-4"
+    data-testid="ollama-section"
+  >
+    <div class="flex items-center justify-between">
+      <h3 class="text-lg font-medium">Ollama</h3>
+    </div>
+
+    <div class="space-y-4">
+      <div class="grid gap-2">
+        <label
+          for="ollama-url"
+          class="text-sm font-medium"
+          >Server URL</label
+        >
+        <div class="flex gap-2">
+          <BaseInput
+            id="ollama-url"
+            v-model="ollamaUrl"
+            placeholder="http://localhost:11434"
+            class="flex-1"
+            :status="urlStatus"
+            :error="urlError"
+            data-testid="ollama-url-input"
+          />
+          <BaseButton
+            variant="secondary"
+            :disabled="isTesting || !isValidUrl"
+            class="shrink-0"
+            data-testid="ollama-test-button"
+            @click="handleTestConnection"
+          >
+            <BaseSpinner
+              v-if="isTesting"
+              size="small"
+              class="mr-2"
+            />
+            Test connection
+          </BaseButton>
+        </div>
+        <p class="text-xs text-secondary-foreground/60">
+          The base URL of your Ollama server. Ensure Ollama is running and accessible.
+        </p>
+      </div>
+
+      <div
+        v-if="testResult"
+        class="p-2 rounded text-sm flex items-center gap-2"
+        :class="testResult.success ? 'bg-success/10 text-success' : 'bg-error/10 text-error'"
+        data-testid="ollama-test-result"
+      >
+        <div :class="testResult.success ? 'i-bi:check-circle' : 'i-bi:exclamation-circle'" />
+        {{ testResult.message }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { ok, err, type Result } from 'neverthrow'
+import { NetworkError } from '@/errors'
+import BaseInput from '@/components/BaseInput.vue'
+import BaseButton from '@/components/BaseButton.vue'
+import BaseSpinner from '@/components/BaseSpinner.vue'
+
+const props = defineProps<{
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const ollamaUrl = computed({
+  get: () => props.modelValue,
+  set: (val) => {
+    emit('update:modelValue', val)
+  },
+})
+
+const isTesting = ref(false)
+const testResult = ref<{ success: boolean; message: string } | null>(null)
+const urlError = ref<string>()
+const urlStatus = computed(() => (urlError.value ? 'invalid' : 'idle'))
+
+const isValidUrl = computed(() => {
+  if (!ollamaUrl.value) return false
+  try {
+    new URL(ollamaUrl.value)
+    return true
+  } catch {
+    return false
+  }
+})
+
+watch(ollamaUrl, () => {
+  testResult.value = null
+  urlError.value = undefined
+})
+
+async function testConnection(url: string): Promise<Result<void, NetworkError>> {
+  try {
+    const targetUrl = url.endsWith('/') ? `${url}api/tags` : `${url}/api/tags`
+    const response = await fetch(targetUrl, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+    })
+
+    if (!response.ok) {
+      return err(
+        new NetworkError(`Ollama returned error: ${response.status} ${response.statusText}`)
+      )
+    }
+
+    return ok(undefined)
+  } catch (unknownError) {
+    return err(
+      new NetworkError(
+        'Failed to connect to Ollama. Ensure it is running and CORS is configured.',
+        unknownError instanceof Error ? unknownError : undefined
+      )
+    )
+  }
+}
+
+async function handleTestConnection() {
+  if (!isValidUrl.value) return
+
+  isTesting.value = true
+  testResult.value = null
+
+  const result = await testConnection(ollamaUrl.value)
+
+  isTesting.value = false
+  result.match(
+    () => {
+      testResult.value = { success: true, message: 'Successfully connected to Ollama!' }
+    },
+    (networkError) => {
+      testResult.value = { success: false, message: networkError.message }
+    }
+  )
+}
+</script>

--- a/src/components/settings/OllamaSection.vue
+++ b/src/components/settings/OllamaSection.vue
@@ -88,8 +88,9 @@ const urlStatus = computed(() => (urlError.value ? 'invalid' : 'idle'))
 const isValidUrl = computed(() => {
   if (!ollamaUrl.value) return false
   try {
-    new URL(ollamaUrl.value)
-    return true
+    const parsed = new URL(ollamaUrl.value)
+    // Only allow http/https — reject file://, javascript:, and other schemes
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
   } catch {
     return false
   }

--- a/src/composables/use-chat-socket.ts
+++ b/src/composables/use-chat-socket.ts
@@ -21,6 +21,14 @@ type MessageCompletePayload = { messageId: number; fullContent: string }
 type ChatErrorPayload = { messageId?: number; error: string }
 type MessageDeletedPayload = { messageId: number }
 
+// Extend the Socket.IO ServerToClientEvents map for events not yet declared in @babadeluxe/shared.
+// TODO: remove this block once @babadeluxe/shared exports `chat:reasoningChunk` in its event map.
+declare module 'socket.io-client' {
+  interface ServerToClientEvents {
+    'chat:reasoningChunk': (payload: MessageChunkPayload) => void
+  }
+}
+
 type AttachedHandlers = Readonly<{
   onChunk: (payload: MessageChunkPayload) => void
   onReasoningChunk: (payload: MessageChunkPayload) => void
@@ -98,27 +106,17 @@ function ensureChatSocketListeners(
     handlersBySocket.set(chatSocket, handlers)
   }
 
-  chatSocket /* @ts-ignore */
-    .off('chat:messageChunk', handlers.onChunk)
-  chatSocket /* @ts-ignore */
-    .off('chat:reasoningChunk', handlers.onReasoningChunk)
-  chatSocket /* @ts-ignore */
-    .off('chat:messageComplete', handlers.onComplete)
-  chatSocket /* @ts-ignore */
-    .off('chat:chatError', handlers.onChatError)
-  chatSocket /* @ts-ignore */
-    .off('chat:messageDeleted', handlers.onDeleted)
+  chatSocket.off('chat:messageChunk', handlers.onChunk)
+  chatSocket.off('chat:reasoningChunk', handlers.onReasoningChunk)
+  chatSocket.off('chat:messageComplete', handlers.onComplete)
+  chatSocket.off('chat:chatError', handlers.onChatError)
+  chatSocket.off('chat:messageDeleted', handlers.onDeleted)
 
-  chatSocket /* @ts-ignore */
-    .on('chat:messageChunk', handlers.onChunk)
-  chatSocket /* @ts-ignore */
-    .on('chat:reasoningChunk', handlers.onReasoningChunk)
-  chatSocket /* @ts-ignore */
-    .on('chat:messageComplete', handlers.onComplete)
-  chatSocket /* @ts-ignore */
-    .on('chat:chatError', handlers.onChatError)
-  chatSocket /* @ts-ignore */
-    .on('chat:messageDeleted', handlers.onDeleted)
+  chatSocket.on('chat:messageChunk', handlers.onChunk)
+  chatSocket.on('chat:reasoningChunk', handlers.onReasoningChunk)
+  chatSocket.on('chat:messageComplete', handlers.onComplete)
+  chatSocket.on('chat:chatError', handlers.onChatError)
+  chatSocket.on('chat:messageDeleted', handlers.onDeleted)
 }
 
 export function registerStreamingHandlers(

--- a/src/composables/use-chat-socket.ts
+++ b/src/composables/use-chat-socket.ts
@@ -23,6 +23,7 @@ type MessageDeletedPayload = { messageId: number }
 
 type AttachedHandlers = Readonly<{
   onChunk: (payload: MessageChunkPayload) => void
+  onReasoningChunk: (payload: MessageChunkPayload) => void
   onComplete: (payload: MessageCompletePayload) => void
   onChatError: (payload: ChatErrorPayload) => void
   onDeleted: (payload: MessageDeletedPayload) => void
@@ -50,6 +51,14 @@ function ensureChatSocketListeners(
       })
 
       state.onChunk?.(payload.chunk)
+    }
+
+    const onReasoningChunk = (payload: MessageChunkPayload) => {
+      const state = store.getMessageState(payload.messageId)
+      if (!state) return
+
+      store.appendReasoning(payload.messageId, payload.chunk)
+      state.onReasoningChunk?.(payload.chunk)
     }
 
     const onComplete = (payload: MessageCompletePayload) => {
@@ -85,25 +94,38 @@ function ensureChatSocketListeners(
       store.deleteMessageState(payload.messageId)
     }
 
-    handlers = { onChunk, onComplete, onChatError, onDeleted }
+    handlers = { onChunk, onReasoningChunk, onComplete, onChatError, onDeleted }
     handlersBySocket.set(chatSocket, handlers)
   }
 
-  chatSocket.off('chat:messageChunk', handlers.onChunk)
-  chatSocket.off('chat:messageComplete', handlers.onComplete)
-  chatSocket.off('chat:chatError', handlers.onChatError)
-  chatSocket.off('chat:messageDeleted', handlers.onDeleted)
+  chatSocket /* @ts-ignore */
+    .off('chat:messageChunk', handlers.onChunk)
+  chatSocket /* @ts-ignore */
+    .off('chat:reasoningChunk', handlers.onReasoningChunk)
+  chatSocket /* @ts-ignore */
+    .off('chat:messageComplete', handlers.onComplete)
+  chatSocket /* @ts-ignore */
+    .off('chat:chatError', handlers.onChatError)
+  chatSocket /* @ts-ignore */
+    .off('chat:messageDeleted', handlers.onDeleted)
 
-  chatSocket.on('chat:messageChunk', handlers.onChunk)
-  chatSocket.on('chat:messageComplete', handlers.onComplete)
-  chatSocket.on('chat:chatError', handlers.onChatError)
-  chatSocket.on('chat:messageDeleted', handlers.onDeleted)
+  chatSocket /* @ts-ignore */
+    .on('chat:messageChunk', handlers.onChunk)
+  chatSocket /* @ts-ignore */
+    .on('chat:reasoningChunk', handlers.onReasoningChunk)
+  chatSocket /* @ts-ignore */
+    .on('chat:messageComplete', handlers.onComplete)
+  chatSocket /* @ts-ignore */
+    .on('chat:chatError', handlers.onChatError)
+  chatSocket /* @ts-ignore */
+    .on('chat:messageDeleted', handlers.onDeleted)
 }
 
 export function registerStreamingHandlers(
   messageId: number,
   handlers: {
     onChunk?: ChunkHandler
+    onReasoningChunk?: ChunkHandler
     onComplete?: CompleteHandler
     onError?: ErrorHandler
   }
@@ -113,6 +135,7 @@ export function registerStreamingHandlers(
 
   store.setMessageState(messageId, {
     onChunk: handlers.onChunk ?? existing?.onChunk,
+    onReasoningChunk: handlers.onReasoningChunk ?? existing?.onReasoningChunk,
     onComplete: handlers.onComplete ?? existing?.onComplete,
     onError: handlers.onError ?? existing?.onError,
     isStreaming: true,
@@ -197,6 +220,7 @@ export function useChatSocket() {
     messages: Array<{ role: 'user' | 'assistant'; content: string }>,
     handlers: {
       onChunk: (chunk: string) => void
+      onReasoningChunk?: (chunk: string) => void
       onComplete: (fullContent: string) => void
       onError?: (errorMessage: string) => void
     }
@@ -232,6 +256,7 @@ export function useChatSocket() {
 
         registerStreamingHandlers(messageId, {
           onChunk: handlers.onChunk,
+          onReasoningChunk: handlers.onReasoningChunk,
           onComplete: (fullContent) => {
             handlers.onComplete(fullContent)
             completion.finishOk()
@@ -304,6 +329,7 @@ export function useChatSocket() {
     messages: Array<{ role: 'user' | 'assistant'; content: string }>,
     handlers: {
       onChunk: (chunk: string) => void
+      onReasoningChunk?: (chunk: string) => void
       onComplete: (fullContent: string) => void
       onError?: (errorMessage: string) => void
     }
@@ -367,10 +393,15 @@ export function useChatSocket() {
 
   const resumeStreamingMessage = (
     messageId: number,
-    handlers: { onChunk: (chunk: string) => void; onComplete?: (fullContent: string) => void }
+    handlers: {
+      onChunk: (chunk: string) => void
+      onReasoningChunk?: (chunk: string) => void
+      onComplete?: (fullContent: string) => void
+    }
   ): void => {
     registerStreamingHandlers(messageId, {
       onChunk: handlers.onChunk,
+      onReasoningChunk: handlers.onReasoningChunk,
       onComplete: handlers.onComplete,
     })
   }

--- a/src/database/app-db.ts
+++ b/src/database/app-db.ts
@@ -14,6 +14,7 @@ type DbMessage = {
   model?: string
   systemPrompt?: string
   contextReferences?: string
+  reasoning?: string
 }
 
 type NewDbMessage = Omit<DbMessage, 'id' | 'timestamp'>
@@ -121,6 +122,12 @@ export class AppDb extends Dexie {
       conversation: '++id, title, isActive, createdAt, updatedAt, &syncId, syncVersion',
       message:
         '++id, conversationId, role, timestamp, model, systemPrompt, contextReferences, isStreaming',
+      localSetting: '++id, settingKey, updatedAt',
+    })
+    this.version(8).stores({
+      conversation: '++id, title, isActive, createdAt, updatedAt, &syncId, syncVersion',
+      message:
+        '++id, conversationId, role, timestamp, model, systemPrompt, contextReferences, isStreaming, reasoning',
       localSetting: '++id, settingKey, updatedAt',
     })
   }

--- a/src/database/app-db.ts
+++ b/src/database/app-db.ts
@@ -124,10 +124,14 @@ export class AppDb extends Dexie {
         '++id, conversationId, role, timestamp, model, systemPrompt, contextReferences, isStreaming',
       localSetting: '++id, settingKey, updatedAt',
     })
+    // v8: adds optional `reasoning` field to message rows.
+    // `reasoning` is NOT indexed — it is a potentially large text field queried only
+    // by messageId (via conversationId). Indexing large strings degrades IndexedDB performance.
+    // No upgrade() callback needed: existing rows return undefined for the new optional field.
     this.version(8).stores({
       conversation: '++id, title, isActive, createdAt, updatedAt, &syncId, syncVersion',
       message:
-        '++id, conversationId, role, timestamp, model, systemPrompt, contextReferences, isStreaming, reasoning',
+        '++id, conversationId, role, timestamp, model, systemPrompt, contextReferences, isStreaming',
       localSetting: '++id, settingKey, updatedAt',
     })
   }

--- a/src/database/chat-repository.ts
+++ b/src/database/chat-repository.ts
@@ -16,6 +16,7 @@ type DbMessage = {
   model?: string
   systemPrompt?: string
   contextReferences?: string
+  reasoning?: string
 }
 
 type NewDbMessage = Omit<DbMessage, 'id' | 'timestamp'>
@@ -37,6 +38,7 @@ type CreateMessageInput = {
   model?: string
   systemPrompt?: string
   contextReferences?: ContextReference[]
+  reasoning?: string
 }
 
 export class ChatRepository {
@@ -75,6 +77,7 @@ export class ChatRepository {
         model: message.model,
         systemPrompt: message.systemPrompt,
         contextReferences: decodeContextReferences(message.contextReferences),
+        reasoning: message.reasoning,
       }))
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
 
@@ -109,6 +112,7 @@ export class ChatRepository {
         model: message.model,
         systemPrompt: message.systemPrompt,
         contextReferences: decodeContextReferences(message.contextReferences),
+        reasoning: message.reasoning,
       }))
 
     return ok(mapped)
@@ -123,6 +127,7 @@ export class ChatRepository {
       model: input.model,
       systemPrompt: input.systemPrompt,
       contextReferences: encodeContextReferences(input.contextReferences),
+      reasoning: input.reasoning,
     })
 
     if (addResult.isErr()) return err(addResult.error)

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -35,6 +35,7 @@ export type Message = {
   model?: string
   systemPrompt?: string
   contextReferences?: ContextReference[]
+  reasoning?: string
 }
 
 export type LocalSetting = {

--- a/src/stores/use-chat-socket-store.ts
+++ b/src/stores/use-chat-socket-store.ts
@@ -7,6 +7,7 @@ type ErrorHandler = (errorMessage: string) => void
 
 export type MessageState = Readonly<{
   onChunk: ChunkHandler | undefined
+  onReasoningChunk: ChunkHandler | undefined
   onComplete: CompleteHandler | undefined
   onError: ErrorHandler | undefined
   isStreaming: boolean
@@ -16,6 +17,7 @@ export type MessageState = Readonly<{
 
 export const useChatSocketStore = defineStore('chatSocket', () => {
   const messageStateById = ref(new Map<number, MessageState>())
+  const reasoningByMessageId = ref(new Map<number, string>())
 
   const setMessageState = (messageId: number, nextState: MessageState): void => {
     messageStateById.value.set(messageId, nextState)
@@ -23,6 +25,7 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
 
   const deleteMessageState = (messageId: number): void => {
     messageStateById.value.delete(messageId)
+    reasoningByMessageId.value.delete(messageId)
   }
 
   const getMessageState = (messageId: number): MessageState | undefined => {
@@ -31,6 +34,7 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
 
   const resetState = (): void => {
     messageStateById.value.clear()
+    reasoningByMessageId.value.clear()
   }
 
   const streamingMessageIds = computed(() => {
@@ -41,12 +45,19 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
     return ids
   })
 
+  const appendReasoning = (messageId: number, chunk: string): void => {
+    const existing = reasoningByMessageId.value.get(messageId) ?? ''
+    reasoningByMessageId.value.set(messageId, existing + chunk)
+  }
+
   return {
     messageStateById,
+    reasoningByMessageId,
     setMessageState,
     deleteMessageState,
     getMessageState,
     resetState,
     streamingMessageIds,
+    appendReasoning,
   }
 })

--- a/src/stores/use-chat-socket-store.ts
+++ b/src/stores/use-chat-socket-store.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed } from 'vue'
+import { ref, computed, shallowRef, triggerRef } from 'vue'
 
 type ChunkHandler = (chunk: string) => void
 type CompleteHandler = (fullContent: string) => void
@@ -17,7 +17,12 @@ export type MessageState = Readonly<{
 
 export const useChatSocketStore = defineStore('chatSocket', () => {
   const messageStateById = ref(new Map<number, MessageState>())
-  const reasoningByMessageId = ref(new Map<number, string>())
+
+  // shallowRef: Map mutations (.set/.delete/.clear) do not auto-track in Vue 3.
+  // All mutations must call triggerRef(_reasoningByMessageId) to notify subscribers.
+  // Exposed as a readonly computed to prevent external mutation — use appendReasoning() instead.
+  const _reasoningByMessageId = shallowRef(new Map<number, string>())
+  const reasoningByMessageId = computed(() => _reasoningByMessageId.value)
 
   const setMessageState = (messageId: number, nextState: MessageState): void => {
     messageStateById.value.set(messageId, nextState)
@@ -25,7 +30,8 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
 
   const deleteMessageState = (messageId: number): void => {
     messageStateById.value.delete(messageId)
-    reasoningByMessageId.value.delete(messageId)
+    _reasoningByMessageId.value.delete(messageId)
+    triggerRef(_reasoningByMessageId)
   }
 
   const getMessageState = (messageId: number): MessageState | undefined => {
@@ -34,7 +40,8 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
 
   const resetState = (): void => {
     messageStateById.value.clear()
-    reasoningByMessageId.value.clear()
+    _reasoningByMessageId.value.clear()
+    triggerRef(_reasoningByMessageId)
   }
 
   const streamingMessageIds = computed(() => {
@@ -46,8 +53,9 @@ export const useChatSocketStore = defineStore('chatSocket', () => {
   })
 
   const appendReasoning = (messageId: number, chunk: string): void => {
-    const existing = reasoningByMessageId.value.get(messageId) ?? ''
-    reasoningByMessageId.value.set(messageId, existing + chunk)
+    const existing = _reasoningByMessageId.value.get(messageId) ?? ''
+    _reasoningByMessageId.value.set(messageId, existing + chunk)
+    triggerRef(_reasoningByMessageId)
   }
 
   return {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -77,6 +77,13 @@
         :field-states="fieldStates"
         @api-key-input="handleApiKeyInput"
       />
+
+      <div class="h-px bg-border my-2" />
+
+      <OllamaSection
+        :model-value="ollamaUrlValue"
+        @update:model-value="handleOllamaUrlChange"
+      />
     </template>
   </section>
 </template>
@@ -93,6 +100,7 @@ import GeneralSettingsSection from '@/components/settings/GeneralSettingsSection
 import PromptBehaviourSection from '@/components/settings/PromptBehaviourSection.vue'
 import ModelPreferencesSection from '@/components/settings/ModelPreferencesSection.vue'
 import ApiKeySection from '@/components/settings/ApiKeySection.vue'
+import OllamaSection from '@/components/settings/OllamaSection.vue'
 import { API_KEY_VALIDATOR_KEY, LOGGER_KEY, SUPABASE_CLIENT_KEY } from '@/injection-keys'
 import { AuthError, InitializationError } from '@/errors'
 import { safeInject } from '@/safe-inject'
@@ -175,6 +183,12 @@ const promptInjectionPosition = computed<PromptInjectionPosition>(() =>
 const promptIncludeHistory = computed<boolean>(() =>
   getSettingValue('promptIncludeHistory', promptInjectionDefaults.includeHistory)
 )
+
+const ollamaUrlValue = computed<string>(() => getSettingValue('ollamaUrl', ''))
+
+const handleOllamaUrlChange = async (value: string) => {
+  await upsertSetting('ollamaUrl', value, 'string')
+}
 
 const handleInjectionModeChange = async (mode: PromptInjectionMode) => {
   await upsertSetting('promptInjectionMode', mode, 'string')

--- a/src/vs-code/context-state.ts
+++ b/src/vs-code/context-state.ts
@@ -206,9 +206,7 @@ export function useContextState() {
    * Suppressed if the file is already present in the pinned set
    * (to avoid showing the same file twice in the context UI).
    */
-  const setActiveEditor = (
-    entry: ActiveEditorEntry,
-  ): void => {
+  const setActiveEditor = (entry: ActiveEditorEntry): void => {
     const key = normalizePath(entry.filePath)
     if (key && pinnedIdsByPath.value.has(key)) {
       // File already pinned — no need for a duplicate active entry
@@ -223,10 +221,7 @@ export function useContextState() {
    * Update the diagnostics map for a given file path.
    * An empty array clears the stored entry.
    */
-  const setDiagnostics = (
-    filePath: string,
-    diagnostics: ReadonlyArray<DiagnosticItem>,
-  ): void => {
+  const setDiagnostics = (filePath: string, diagnostics: ReadonlyArray<DiagnosticItem>): void => {
     const next = new Map(diagnosticsMap.value)
     if (diagnostics.length === 0) {
       next.delete(filePath)
@@ -240,9 +235,8 @@ export function useContextState() {
    * Returns diagnostics for a given file if any exist, otherwise undefined.
    * Use this when building the socket payload to optionally attach diagnostics.
    */
-  const getDiagnosticsForFile = (
-    filePath: string,
-  ): ReadonlyArray<DiagnosticItem> | undefined => diagnosticsMap.value.get(filePath)
+  const getDiagnosticsForFile = (filePath: string): ReadonlyArray<DiagnosticItem> | undefined =>
+    diagnosticsMap.value.get(filePath)
 
   return {
     pinnedPaths,

--- a/src/vs-code/context-type-guards.ts
+++ b/src/vs-code/context-type-guards.ts
@@ -61,6 +61,8 @@ export const isActiveEditorChangedMessage = (
 export const isEditorDiagnosticsMessage = (msg: IncomingMessage): msg is EditorDiagnosticsMessage =>
   msg.type === 'editor:diagnostics'
 
+/** Guard for VS Code context item objects passed from the extension host.
+ *  Matches the shape used by context:pinFile and context:snapshot message handlers. */
 export const isVsCodeContextItem = (
   value: unknown
 ): value is { id: string; filePath: string; kind: 'pinned' | 'suggested' } => {
@@ -73,6 +75,7 @@ export const isVsCodeContextItem = (
   )
 }
 
+/** Guard for extension host responses that carry a requestId correlation token. */
 export const isResponseWithRequestId = (value: unknown): value is { requestId: string } => {
   if (typeof value !== 'object' || value === null) return false
   const v = value as Record<string, unknown>

--- a/src/vs-code/context-type-guards.ts
+++ b/src/vs-code/context-type-guards.ts
@@ -54,10 +54,27 @@ export const isGitPrMessageContext = (msg: IncomingMessage): msg is GitPrMessage
 
 /** Guard for active editor change notifications from the extension host. */
 export const isActiveEditorChangedMessage = (
-  msg: IncomingMessage,
+  msg: IncomingMessage
 ): msg is ActiveEditorChangedMessage => msg.type === 'editor:activeChanged'
 
 /** Guard for diagnostics notifications from the extension host. */
-export const isEditorDiagnosticsMessage = (
-  msg: IncomingMessage,
-): msg is EditorDiagnosticsMessage => msg.type === 'editor:diagnostics'
+export const isEditorDiagnosticsMessage = (msg: IncomingMessage): msg is EditorDiagnosticsMessage =>
+  msg.type === 'editor:diagnostics'
+
+export const isVsCodeContextItem = (
+  value: unknown
+): value is { id: string; filePath: string; kind: 'pinned' | 'suggested' } => {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v['id'] === 'string' &&
+    typeof v['filePath'] === 'string' &&
+    (v['kind'] === 'pinned' || v['kind'] === 'suggested')
+  )
+}
+
+export const isResponseWithRequestId = (value: unknown): value is { requestId: string } => {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return typeof v['requestId'] === 'string'
+}

--- a/tests/unit/components/ChatReasoningBlock.spec.ts
+++ b/tests/unit/components/ChatReasoningBlock.spec.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import ChatReasoningBlock from '@/components/ChatReasoningBlock.vue'
+
+const markdownRendererMock = defineComponent({
+  props: {
+    content: { type: String, required: true },
+  },
+  template: '<div>{{ content }}</div>',
+})
+
+describe('ChatReasoningBlock', () => {
+  it('renders reasoning content when provided', () => {
+    const wrapper = mount(ChatReasoningBlock, {
+      props: {
+        reasoning: 'I am thinking about the answer.',
+        isStreaming: false,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: markdownRendererMock,
+        },
+      },
+    })
+    expect(wrapper.find('[data-testid="reasoning-content"]').text()).toContain(
+      'I am thinking about the answer.'
+    )
+  })
+
+  it('shows "Thinking…" when streaming', () => {
+    const wrapper = mount(ChatReasoningBlock, {
+      props: {
+        reasoning: 'Thinking...',
+        isStreaming: true,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: markdownRendererMock,
+        },
+      },
+    })
+    expect(wrapper.find('[data-testid="reasoning-summary"]').text()).toContain('Thinking…')
+    expect(wrapper.find('.animate-pulse').exists()).toBe(true)
+  })
+
+  it('shows "Reasoning" when not streaming', () => {
+    const wrapper = mount(ChatReasoningBlock, {
+      props: {
+        reasoning: 'Thought complete.',
+        isStreaming: false,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: markdownRendererMock,
+        },
+      },
+    })
+    expect(wrapper.find('[data-testid="reasoning-summary"]').text()).toContain('Reasoning')
+    expect(wrapper.find('.animate-pulse').exists()).toBe(false)
+  })
+
+  it('calculates token count correctly (heuristic)', () => {
+    const reasoning = '12345678' // 8 chars -> 2 tokens
+    const wrapper = mount(ChatReasoningBlock, {
+      props: {
+        reasoning,
+        isStreaming: false,
+      },
+      global: {
+        stubs: {
+          MarkdownRenderer: markdownRendererMock,
+        },
+      },
+    })
+    expect(wrapper.find('[data-testid="reasoning-tokens"]').text()).toBe('2 tokens')
+  })
+})

--- a/tests/unit/components/settings/OllamaSection.spec.ts
+++ b/tests/unit/components/settings/OllamaSection.spec.ts
@@ -56,6 +56,23 @@ describe('OllamaSection', () => {
     expect(button.element.disabled).toBe(false)
   })
 
+  it('rejects non-http/https protocols (file:// should disable button)', async () => {
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'file:///etc/hosts' },
+      global: {
+        stubs: {
+          BaseButton: {
+            template: '<button :disabled="disabled"><slot /></button>',
+            props: ['disabled'],
+          },
+          BaseInput: true,
+          BaseSpinner: true,
+        },
+      },
+    })
+    expect(wrapper.find('button').element.disabled).toBe(true)
+  })
+
   it('shows success message on successful connection', async () => {
     vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
 
@@ -65,9 +82,46 @@ describe('OllamaSection', () => {
     })
 
     await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
 
     expect(wrapper.find('[data-testid="ollama-test-result"]').text()).toContain(
       'Successfully connected'
     )
+  })
+
+  it('shows error message on failed connection (non-ok response)', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as Response)
+
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'http://localhost:11434' },
+      global: globalConfig,
+    })
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const result = wrapper.find('[data-testid="ollama-test-result"]')
+    expect(result.exists()).toBe(true)
+    expect(result.text()).toContain('Ollama returned error: 503')
+  })
+
+  it('shows error message when fetch throws (network unreachable)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network request failed'))
+
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'http://localhost:11434' },
+      global: globalConfig,
+    })
+
+    await wrapper.find('button').trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const result = wrapper.find('[data-testid="ollama-test-result"]')
+    expect(result.exists()).toBe(true)
+    expect(result.text()).toContain('Failed to connect to Ollama')
   })
 })

--- a/tests/unit/components/settings/OllamaSection.spec.ts
+++ b/tests/unit/components/settings/OllamaSection.spec.ts
@@ -1,0 +1,73 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import OllamaSection from '@/components/settings/OllamaSection.vue'
+
+describe('OllamaSection', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  const globalConfig = {
+    stubs: {
+      BaseButton: {
+        template: '<button><slot /></button>',
+      },
+      BaseInput: {
+        template:
+          '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+        props: ['modelValue'],
+      },
+      BaseSpinner: true,
+    },
+  }
+
+  it('renders correctly', () => {
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'http://localhost:11434' },
+      global: globalConfig,
+    })
+    expect(wrapper.find('[data-testid="ollama-section"]').exists()).toBe(true)
+    expect(wrapper.find('input').element.value).toBe('http://localhost:11434')
+  })
+
+  it('validates URL and enables/disables test button', async () => {
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'not-a-url' },
+      global: {
+        stubs: {
+          BaseButton: {
+            template: '<button :disabled="disabled"><slot /></button>',
+            props: ['disabled'],
+          },
+          BaseInput: true,
+          BaseSpinner: true,
+        },
+      },
+    })
+
+    const button = wrapper.find('button')
+    expect(button.element.disabled).toBe(true)
+
+    await wrapper.setProps({ modelValue: 'http://localhost:11434' })
+    expect(button.element.disabled).toBe(false)
+  })
+
+  it('shows success message on successful connection', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response)
+
+    const wrapper = mount(OllamaSection, {
+      props: { modelValue: 'http://localhost:11434' },
+      global: globalConfig,
+    })
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.find('[data-testid="ollama-test-result"]').text()).toContain(
+      'Successfully connected'
+    )
+  })
+})

--- a/tests/unit/socket-contract.spec.ts
+++ b/tests/unit/socket-contract.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+const messageChunkSchema = z.object({
+  messageId: z.number(),
+  chunk: z.string(),
+  sequence: z.number(),
+})
+
+describe('Socket Contract Validation', () => {
+  it('validates message chunk payload', () => {
+    const payload = { messageId: 123, chunk: 'hello', sequence: 1 }
+    expect(messageChunkSchema.parse(payload)).toEqual(payload)
+  })
+
+  it('validates reasoning chunk payload', () => {
+    const payload = { messageId: 123, chunk: 'thinking...', sequence: 1 }
+    expect(messageChunkSchema.parse(payload)).toEqual(payload)
+  })
+
+  it('fails on invalid payload', () => {
+    const payload = { messageId: '123', chunk: 456 }
+    expect(() => messageChunkSchema.parse(payload)).toThrow()
+  })
+})

--- a/tests/unit/stores/use-chat-socket-store.spec.ts
+++ b/tests/unit/stores/use-chat-socket-store.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useChatSocketStore } from '@/stores/use-chat-socket-store'
+
+describe('useChatSocketStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('appends reasoning chunks', () => {
+    const store = useChatSocketStore()
+    store.appendReasoning(1, 'Thinking')
+    store.appendReasoning(1, '...')
+    expect(store.reasoningByMessageId.get(1)).toBe('Thinking...')
+  })
+
+  it('deletes reasoning when message state is deleted', () => {
+    const store = useChatSocketStore()
+    store.appendReasoning(1, 'Thinking')
+    store.deleteMessageState(1)
+    expect(store.reasoningByMessageId.has(1)).toBe(false)
+  })
+
+  it('resets all state', () => {
+    const store = useChatSocketStore()
+    store.appendReasoning(1, 'Thinking')
+    store.setMessageState(1, {
+      onChunk: undefined,
+      onReasoningChunk: undefined,
+      onComplete: undefined,
+      onError: undefined,
+      isStreaming: true,
+      lastSequence: 1,
+    })
+    store.resetState()
+    expect(store.reasoningByMessageId.size).toBe(0)
+    expect(store.messageStateById.size).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR implements two major features: Visible Reasoning Steps (Perplexity-style) and Ollama support.

1. **Visible Reasoning Steps**:
   - Added `reasoning` field to the `Message` type and IndexedDB schema (version 8).
   - Updated `useChatSocketStore` to track live reasoning chunks during streaming.
   - Updated `useChatSocket` to listen for `chat:reasoningChunk` events.
   - Created `ChatReasoningBlock.vue`, a collapsible component with animated streaming text and token counting.
   - Integrated `ChatReasoningBlock` into `ChatMessage.vue`.

2. **Ollama Support**:
   - Created `OllamaSection.vue` in settings for configuring `ollamaUrl`.
   - Implemented a "Test connection" button that pings the Ollama `/api/tags` endpoint.
   - Wired the new section into `SettingsView.vue`.

**Additional Changes**:
- Fixed missing exports in `vs-code/context-type-guards.ts`.
- Added `@ts-ignore` for `chat:reasoningChunk` socket listeners due to missing types in `@babadeluxe/shared`.
- Standardized test organization by moving tests to `tests/unit/`.
- Ensured all tests pass and follow the repository's naming and coding conventions.

---
*PR created automatically by Jules for task [12467285927857387192](https://jules.google.com/task/12467285927857387192) started by @simwai*