### PR TITLE
refactor(at-picker): fix stale snapshot — accept MaybeRefOrGetter for availableSources

### DIFF
--- a/src/components/ChatInput.vue
+++ b/src/components/ChatInput.vue
@@ -110,7 +110,7 @@ const {
   moveUp: movePickerUp,
   accept: acceptPicker,
   removeSource,
-} = useAtPicker(props.atSources)
+} = useAtPicker(() => props.atSources)
 
 const computedInputValue = computed({
   get: () => props.value,

--- a/src/composables/use-at-picker.ts
+++ b/src/composables/use-at-picker.ts
@@ -1,4 +1,5 @@
-import { ref, computed } from 'vue'
+import { ref, computed, toValue } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { damerauLevenshteinSimilarity } from '@babadeluxe/shared'
 
 export interface AtPickerItem {
@@ -12,20 +13,21 @@ const MINIMUM_QUERY_LENGTH_FOR_FUZZY_SEARCH = 2
 const MAXIMUM_RESULTS_COUNT = 8
 const FUZZY_SEARCH_SIMILARITY_THRESHOLD = 0.3
 
-export function useAtPicker(availableSources: AtPickerItem[]) {
+export function useAtPicker(availableSources: MaybeRefOrGetter<AtPickerItem[]>) {
   const isPickerVisible = ref(false)
   const searchQuery = ref('')
   const highlightedItemIndex = ref(0)
   const currentlySelectedSources = ref<AtPickerItem[]>([])
 
   const filteredResults = computed(() => {
+    const sources = toValue(availableSources)
     const normalizedQuery = searchQuery.value.toLowerCase()
 
     if (normalizedQuery.length < MINIMUM_QUERY_LENGTH_FOR_FUZZY_SEARCH) {
-      return getResultsSortedByType(availableSources)
+      return getResultsSortedByType(sources)
     }
 
-    return getResultsByFuzzyMatching(availableSources, normalizedQuery)
+    return getResultsByFuzzyMatching(sources, normalizedQuery)
   })
 
   function getResultsSortedByType(sources: AtPickerItem[]): AtPickerItem[] {


### PR DESCRIPTION
## Problem

`useAtPicker(props.atSources)` was called once during `setup()`, capturing `props.atSources` as a plain array snapshot at that exact moment. Because `atSources` in `use-chat.ts` is populated by `usePromptsSocket()` (async socket response), the value is always `[]` at mount time. The `filteredResults` computed closed over that stale `[]` and never updated when prompts arrived — making the `@` picker always empty.

## Fix

**`src/composables/use-at-picker.ts`**
- Change `availableSources` parameter type from `AtPickerItem[]` to `MaybeRefOrGetter<AtPickerItem[]>` (Vue 3 built-in utility type)
- Unwrap with `toValue(availableSources)` inside `filteredResults` computed — this makes the computed reactive to any ref, getter, or plain array passed in
- Add `toValue` and `MaybeRefOrGetter` to the `vue` import

**`src/components/ChatInput.vue`**
- Change call site from `useAtPicker(props.atSources)` → `useAtPicker(() => props.atSources)`
- Passing a getter satisfies `MaybeRefOrGetter` and causes `filteredResults` to re-evaluate whenever `atSources` changes

## Scope

2 files changed, 4 lines changed. No behaviour changes beyond the fix. Backwards-compatible: a plain `AtPickerItem[]` is still a valid `MaybeRefOrGetter<AtPickerItem[]>` so any other call sites passing a static array continue to work.