### PR TITLE
Fix build errors and type mismatches

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@babadeluxe/shared':
-        specifier: ^0.22.0
-        version: 0.22.0(socket.io@4.8.3)(typescript@5.8.3)
+        specifier: ^0.24.0
+        version: 0.24.0(socket.io@4.8.3)(typescript@5.8.3)
       '@lottiefiles/dotlottie-vue':
         specifier: ^0.10.1
         version: 0.10.15(vue@3.5.32(typescript@5.8.3))
@@ -234,9 +234,8 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
-  '@babadeluxe/shared@0.22.0':
-    resolution: {integrity: sha512-zyYuarS6Sj7t4T5iuCqZXq3L0VeK1O30UBao1J9NeVSEUdYdi64dp3CWI8ToFqU5T5zGrpJVfUe6yNneYkHVLQ==, tarball: http://npflared.simonwaiblinger.workers.dev/@babadeluxe/shared/-/@babadeluxe/shared-0.22.0.tgz}
-    engines: {node: '>=20.19 <24'}
+  '@babadeluxe/shared@0.24.0':
+    resolution: {integrity: sha512-NxbNfJu0J54FfU9RdoST/25Og9fMmlAdl5e+aIPY2sUTPmyWg/BFc9VIL3bVRIKLZ5irS2XMSQVZJOoqiez9Dw==, tarball: http://npflared.simonwaiblinger.workers.dev/@babadeluxe/shared/-/@babadeluxe/shared-0.24.0.tgz}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4950,6 +4949,9 @@ packages:
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@antfu/install-pkg@1.1.0':
@@ -4965,13 +4967,13 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
 
-  '@babadeluxe/shared@0.22.0(socket.io@4.8.3)(typescript@5.8.3)':
+  '@babadeluxe/shared@0.24.0(socket.io@4.8.3)(typescript@5.8.3)':
     dependencies:
       dotenv: 17.4.1
       neverthrow: 8.2.0
       socket.io-client: 4.8.3
-      zod: 4.3.6
-      zod-sockets: 5.3.0(socket.io@4.8.3)(typescript@5.8.3)(zod@4.3.6)
+      zod: 4.4.3
+      zod-sockets: 5.3.0(socket.io@4.8.3)(typescript@5.8.3)(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - socket.io
@@ -10124,13 +10126,15 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
-  zod-sockets@5.3.0(socket.io@4.8.3)(typescript@5.8.3)(zod@4.3.6):
+  zod-sockets@5.3.0(socket.io@4.8.3)(typescript@5.8.3)(zod@4.4.3):
     dependencies:
       ansis: 4.2.0
       ramda: 0.32.0
       socket.io: 4.8.3
       typescript: 5.8.3
       yaml: 2.8.3
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}

--- a/src/components/SettingsField.vue
+++ b/src/components/SettingsField.vue
@@ -44,7 +44,7 @@
 import { computed } from 'vue'
 
 interface Setting {
-  dataType: 'string' | 'number' | 'boolean'
+  dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
   settingValue: unknown
 }
 
@@ -78,7 +78,7 @@ const booleanValue = computed(() => {
 function handleInput(event: Event) {
   const target = event.target as HTMLInputElement
   const value = props.setting.dataType === 'number' ? Number(target.value) : target.value
-  emit('field-changed', props.fieldName, value)
+  emit('field-changed', props.fieldName, value as string | number | boolean)
 }
 
 function handleCheckbox(event: Event) {

--- a/src/composables/use-api-key-management.ts
+++ b/src/composables/use-api-key-management.ts
@@ -21,7 +21,7 @@ export function useApiKeyManagement<T, E>(
   upsertSetting: (
     key: string,
     value: unknown,
-    type: 'string' | 'number' | 'boolean'
+    type: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
   ) => Promise<void>,
   reloadModels: () => Promise<Result<T, E>>,
   getCurrentUserId: () => string | undefined,
@@ -30,7 +30,7 @@ export function useApiKeyManagement<T, E>(
       readonly {
         readonly settingKey: string
         readonly settingValue: Readonly<unknown>
-        readonly dataType: 'string' | 'number' | 'boolean'
+        readonly dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
         readonly updatedAt: string | Date
         readonly category: string
         readonly encrypted: boolean
@@ -44,7 +44,7 @@ export function useApiKeyManagement<T, E>(
       readonly {
         readonly settingKey: string
         readonly settingValue: Readonly<unknown>
-        readonly dataType: 'string' | 'number' | 'boolean'
+        readonly dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
         readonly updatedAt: string | Date
         readonly category: string
         readonly encrypted: boolean

--- a/src/composables/use-chat-socket.ts
+++ b/src/composables/use-chat-socket.ts
@@ -108,7 +108,6 @@ function ensureChatSocketListeners(
 
   chatSocket.off('chat:messageChunk', attachedHandlers.onChunk)
   // TODO(#issue): add chat:reasoningChunk to socket Emission type — event exists on server but not yet in shared Emission map
-  // @ts-expect-error - chat:reasoningChunk missing from Emission type
   chatSocket.off('chat:reasoningChunk', attachedHandlers.onReasoningChunk)
   chatSocket.off('chat:messageComplete', attachedHandlers.onComplete)
   chatSocket.off('chat:chatError', attachedHandlers.onChatError)
@@ -116,7 +115,6 @@ function ensureChatSocketListeners(
 
   chatSocket.on('chat:messageChunk', attachedHandlers.onChunk)
   // TODO(#issue): add chat:reasoningChunk to socket Emission type — event exists on server but not yet in shared Emission map
-  // @ts-expect-error - chat:reasoningChunk missing from Emission type
   chatSocket.on('chat:reasoningChunk', attachedHandlers.onReasoningChunk)
   chatSocket.on('chat:messageComplete', attachedHandlers.onComplete)
   chatSocket.on('chat:chatError', attachedHandlers.onChatError)

--- a/src/composables/use-settings.ts
+++ b/src/composables/use-settings.ts
@@ -87,7 +87,7 @@ export function useSettings() {
   const upsertSetting = async (
     settingKey: string,
     settingValue: unknown,
-    dataType: 'string' | 'number' | 'boolean'
+    dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
   ): Promise<Result<void, NetworkError>> => {
     error.value = undefined
     const result = await repository.upsertSetting(settingKey, settingValue, dataType)

--- a/src/database/app-db.ts
+++ b/src/database/app-db.ts
@@ -21,7 +21,6 @@ type DbMessage = {
   systemPrompt?: string
   reasoning?: string
   contextReferences?: string
-  reasoning?: string
 }
 
 type NewDbMessage = Omit<DbMessage, 'id' | 'timestamp'>

--- a/src/database/chat-repository.ts
+++ b/src/database/chat-repository.ts
@@ -17,7 +17,6 @@ type DbMessage = {
   systemPrompt?: string
   reasoning?: string
   contextReferences?: string
-  reasoning?: string
 }
 
 type NewDbMessage = Omit<DbMessage, 'id' | 'timestamp'>
@@ -40,7 +39,6 @@ type CreateMessageInput = {
   systemPrompt?: string
   reasoning?: string
   contextReferences?: ContextReference[]
-  reasoning?: string
 }
 
 export class ChatRepository {
@@ -80,7 +78,6 @@ export class ChatRepository {
         systemPrompt: message.systemPrompt,
         reasoning: message.reasoning,
         contextReferences: decodeContextReferences(message.contextReferences),
-        reasoning: message.reasoning,
       }))
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
 
@@ -116,7 +113,6 @@ export class ChatRepository {
         systemPrompt: message.systemPrompt,
         reasoning: message.reasoning,
         contextReferences: decodeContextReferences(message.contextReferences),
-        reasoning: message.reasoning,
       }))
 
     return ok(mapped)
@@ -132,7 +128,6 @@ export class ChatRepository {
       systemPrompt: input.systemPrompt,
       reasoning: input.reasoning,
       contextReferences: encodeContextReferences(input.contextReferences),
-      reasoning: input.reasoning,
     })
 
     if (addResult.isErr()) return err(addResult.error)

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -36,14 +36,13 @@ export type Message = {
   systemPrompt?: string
   reasoning?: string
   contextReferences?: ContextReference[]
-  reasoning?: string
 }
 
 export type LocalSetting = {
   id?: number
   settingKey: string
   settingValue: unknown
-  dataType: 'string' | 'number' | 'boolean'
+  dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
   updatedAt: Date
 }
 

--- a/src/merge-settings.ts
+++ b/src/merge-settings.ts
@@ -33,7 +33,7 @@ export function mergePartialUpdate(
   const updated = [...settings]
   updated[index] = {
     ...updated[index],
-    dataType: update.dataType as 'string' | 'number' | 'boolean',
+    dataType: update.dataType as 'string' | 'number' | 'boolean' | 'json-object',
     settingValue: update.settingValue,
     updatedAt: new Date(update.updatedAt),
   }

--- a/src/repositories/settings-repository.ts
+++ b/src/repositories/settings-repository.ts
@@ -7,7 +7,7 @@ export interface SettingsRepository {
   upsertSetting(
     settingKey: string,
     settingValue: unknown,
-    dataType: 'string' | 'number' | 'boolean'
+    dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
   ): Promise<Result<void, NetworkError>>
   deleteSetting(settingKey: string): Promise<Result<void, NetworkError>>
 }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -307,7 +307,7 @@ async function handleTemperatureReset(modelValue: string): Promise<void> {
 async function upsertSettingWrapper(
   key: string,
   value: unknown,
-  dataType: 'string' | 'number' | 'boolean'
+  dataType: 'string' | 'number' | 'boolean' | 'json-object' | 'json-array'
 ): Promise<void> {
   const result = await upsertSetting(key, value, dataType)
 

--- a/tests/settings-view.integration.test.ts
+++ b/tests/settings-view.integration.test.ts
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
-import { ref, reactive, readonly } from 'vue'
+import { ref, reactive } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import type { AsyncInjectable } from '@/injection-keys'
 import { API_KEY_VALIDATOR_KEY, LOGGER_KEY, SUPABASE_CLIENT_KEY } from '@/injection-keys'
@@ -11,10 +11,6 @@ import SettingsView from '@/views/SettingsView.vue'
 import { ok } from 'neverthrow'
 vi.mock('@/composables/use-settings', () => ({
   useSettings: () => ({
-    // settings: reactive({ value: [] }),
-    // upsertSetting: vi.fn(),
-    // loadSettings: vi.fn().mockResolvedValue(undefined),
-
     settings: ref([]),
     upsertSetting: vi.fn().mockResolvedValue(ok(undefined)),
     loadSettings: vi.fn().mockResolvedValue(ok(undefined)),
@@ -23,7 +19,6 @@ vi.mock('@/composables/use-settings', () => ({
 
 vi.mock('@/composables/use-models-socket', () => ({
   useModelsSocket: () => ({
-    reloadModels: vi.fn(),
     models: ref({
       openai: [],
       anthropic: [],
@@ -37,7 +32,7 @@ vi.mock('@/composables/use-models-socket', () => ({
 }))
 
 vi.mock('@/composables/use-theme', () => ({
-  useTheme: () => ({ isDark: reactive({ value: false }), toggleDark: vi.fn() }),
+  useTheme: () => ({ isDark: ref(false), toggleDark: vi.fn() }),
 }))
 
 vi.mock('@/stores/use-toast-store', () => ({


### PR DESCRIPTION
This PR fixes several build and type-checking errors:
1. Duplicate 'reasoning' fields in `AppDb`, `ChatRepository`, and `Message` types were causing 'duplicate identifier' and 'multiple properties with same name' errors.
2. The `SettingDataType` from `@babadeluxe/shared` includes 'json-object' and 'json-array', which were missing from local type definitions and interfaces, causing assignment errors.
3. Unused `@ts-expect-error` directives in `use-chat-socket.ts` were removed.
4. Integration tests were updated to use `ref` instead of `reactive` for `isDark` to avoid Vue prop type warnings.

---
*PR created automatically by Jules for task [13084792246321469581](https://jules.google.com/task/13084792246321469581) started by @simwai*