### PR TITLE
Documentation Regression-Prevention Pass (June 2026)

### DIFF
--- a/DOC_DRIFT.md
+++ b/DOC_DRIFT.md
@@ -163,3 +163,29 @@ This file documents discrepancies between the codebase implementation and the pr
 - `docs/ENVS.md`
 - `docs/SYNC_DESIGN.md`
 - `DOC_DRIFT.md`
+
+---
+
+## Pass Summary: 2026-06-07
+
+**Branch Analyzed:** `dev`
+
+**Files Reviewed:**
+
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `docs/SYNC_DESIGN.md`
+- `docs/ENVS.md`
+
+**Regressions Found & Fixed:**
+
+- **AI Reasoning:** `docs/ARCHITECTURE.md` was missing documentation for the `chat:reasoningChunk` event and the `reasoning` field in the `AppDb` schema (v8).
+- **At-Mentions:** The new `@` mention picker and atomic `AtPill.vue` rendering were undocumented in the core architecture.
+- **Subscriptions:** Reactive tier/status management via `use-subscription-socket.ts` was missing from the service documentation.
+- **Composer Features:** `README.md` was updated to highlight the new rich composer and reasoning support as user-facing features.
+
+**Files Changed:**
+
+- `README.md`
+- `docs/ARCHITECTURE.md`
+- `DOC_DRIFT.md`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This repo contains the frontend that runs inside the VS Code webview panel. It c
 - **State:** Pinia
 - **Build:** Vite
 - **Styling:** UnoCSS (Tailwind conventions)
-- **Persistence:** Dexie.js (IndexedDB)
+- **Persistence:** Dexie.js (IndexedDB) with AI Reasoning support
+- **Rich Composer:** Fuzzy-matching @mentions
 - **Synchronization:** GitHub (REST)
 - **Real-time:** Socket.io-client
 - **Validation:** Zod + neverthrow

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,7 @@ Raw Dexie collections are wrapped in `SafeCollection` and `SafeTable` to enforce
 
 ### ChatRepository
 
-`src/database/chat-repository.ts` holds all chat business logic (message CRUD, conversation cascade delete, streaming message resolution). `AppDb` owns the schema, hooks, and `SafeTable` wrappers and exposes a `chatRepository` getter — it no longer contains domain methods directly.
+`src/database/chat-repository.ts` holds all chat business logic (message CRUD, conversation cascade delete, streaming message resolution). `AppDb` owns the schema, hooks, and `SafeTable` wrappers and exposes a `chatRepository` getter — it no longer contains domain methods directly. The `message` table (v8) includes an optional `reasoning` field for AI thought process streaming.
 
 ### KeyValueDb
 
@@ -143,6 +143,20 @@ Logic is encapsulated in composables rather than bloated components:
 | `use-tracked-timeouts`      | Register timeouts that are automatically cleared on unmount |
 | `use-socket-listener`       | Type-safe Socket.io event subscriptions                     |
 | `use-date-formatter`        | Locale-aware date/time formatting                           |
+| `use-at-picker`             | Fuzzy-matching for @mentions in the chat composer           |
+| `use-subscription-socket`   | Reactive subscription tier and billing status management    |
+
+## AI Reasoning
+
+The system supports real-time streaming of AI reasoning processes. The `chat:reasoningChunk` socket event appends data to the active message's `reasoning` field. These are rendered via a collapsible `ReasoningBlock.vue` component with a pulsing animation, allowing users to inspect the model's logic without cluttering the primary conversation flow.
+
+## At-Mentions (@)
+
+The chat composer features an `@` mention picker powered by `use-at-picker.ts`. It utilizes an inline Damerau-Levenshtein distance algorithm for fuzzy matching (activated after 2+ characters). Selections are rendered as atomic `AtPill.vue` units within the input area.
+
+## Subscription Management
+
+User access levels are managed via a reactive subscription system. `use-subscription-socket.ts` monitors the `subscription:updated` event to update the user's tier (`FREE`, `PRO`) and status (`active`, `past_due`, etc.). UI components like `SubscriptionModal.vue` use this state to gate features or prompt for upgrades.
 
 ## Streaming & Rendering
 


### PR DESCRIPTION
This PR addresses documentation drift in the repository by aligning the architecture and overview documents with the current implementation.

Key changes:
- **AI Reasoning:** Documented the `chat:reasoningChunk` event and the `reasoning` field in the IndexedDB schema (v8).
- **At-Mentions (@):** Added documentation for the fuzzy-matching mention picker and `AtPill.vue` rendering.
- **Subscriptions:** Documented the reactive tier and status management via `use-subscription-socket.ts`.
- **Feature Highlights:** Updated the `README.md` feature list to include these recent additions.
- **Report:** Updated `DOC_DRIFT.md` with a detailed record of the reconciliation pass.

All changes are documentation-only and have been verified against the source code.

---
*PR created automatically by Jules for task [3434347992510123206](https://jules.google.com/task/3434347992510123206) started by @simwai*